### PR TITLE
Better progress estimations when capping payload limits

### DIFF
--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Not_Perform_Download_Speed_Test.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Not_Perform_Download_Speed_Test.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Upload: 18.67 Kbps
+Test Sponsor 1
+Latency: 100 ms, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Not_Perform_Upload_Speed_Test.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Not_Perform_Upload_Speed_Test.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 8 Kbps
+Test Sponsor 1
+Latency: 100 ms, Download: 8 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 8 Kbps Upload: 18.67 Kbps
+Test Sponsor 1
+Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_Latency_Only.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_Latency_Only.verified.txt
@@ -1,0 +1,4 @@
+Test Sponsor 1
+Latency: 100 ms
+
+Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp,Download,Upload
-1980-01-01 10:05:00,8 Kbps,18.67 Kbps
+Timestamp,Latency,Download,Upload
+1980-01-01 10:05:00,100 ms,8 Kbps,18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=,.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=,.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp,Download,Upload
-1980-01-01 10:05:00,8 Kbps,18.67 Kbps
+Timestamp,Latency,Download,Upload
+1980-01-01 10:05:00,100 ms,8 Kbps,18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=-.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=-.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp	Download	Upload
-1980-01-01 10:05:00	8 Kbps	18.67 Kbps
+Timestamp	Latency	Download	Upload
+1980-01-01 10:05:00	100 ms	8 Kbps	18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=;.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_Delimiter_delimiter=;.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp;Download;Upload
-1980-01-01 10:05:00;8 Kbps;18.67 Kbps
+Timestamp;Latency;Download;Upload
+1980-01-01 10:05:00;100 ms;8 Kbps;18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_No_Download.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_No_Download.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp,Upload
-1980-01-01 10:05:00,18.67 Kbps
+Timestamp,Latency,Upload
+1980-01-01 10:05:00,100 ms,18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_No_Upload.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_CSV_No_Upload.verified.txt
@@ -1,2 +1,2 @@
-﻿Timestamp,Download
-1980-01-01 10:05:00,8 Kbps
+Timestamp,Latency,Download
+1980-01-01 10:05:00,100 ms,8 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Timestamp.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Timestamp.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-1980-01-01 10:05:00 Download: 8 Kbps Upload: 18.67 Kbps
+Test Sponsor 1
+1980-01-01 10:05:00, Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BitsPerSecond_unitSystem=IEC.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BitsPerSecond_unitSystem=IEC.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 7.81 Kibps Upload: 18.23 Kibps
+Test Sponsor 1
+Latency: 100 ms, Download: 7.81 Kibps, Upload: 18.23 Kibps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BitsPerSecond_unitSystem=SI.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BitsPerSecond_unitSystem=SI.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 8 Kbps Upload: 18.67 Kbps
+Test Sponsor 1
+Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BytesPerSecond_unitSystem=IEC.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BytesPerSecond_unitSystem=IEC.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 1000 Bps Upload: 2.28 KiBps
+Test Sponsor 1
+Latency: 100 ms, Download: 1000 Bps, Upload: 2.28 KiBps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BytesPerSecond_unitSystem=SI.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Units_unit=BytesPerSecond_unitSystem=SI.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 1 KBps Upload: 2.33 KBps
+Test Sponsor 1
+Latency: 100 ms, Download: 1 KBps, Upload: 2.33 KBps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Debug.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Debug.verified.txt
@@ -1,6 +1,6 @@
-﻿Test Sponsor 1 (100 ms)
+Test Sponsor 1
 1 KB downloaded in 1 second
 7 KB uploaded in 3 seconds
-Download: 8 Kbps Upload: 18.67 Kbps
+Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Minimal.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Minimal.verified.txt
@@ -1,1 +1,1 @@
-﻿Download: 8 Kbps Upload: 18.67 Kbps
+Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps

--- a/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Normal.verified.txt
+++ b/src/NetPace.Console.Tests/Expectations/NetPaceConsoleTests.Should_Perform_Speed_Test_With_Verbosity_verbosity=Normal.verified.txt
@@ -1,4 +1,4 @@
-﻿Test Sponsor 1 (100 ms)
-Download: 8 Kbps Upload: 18.67 Kbps
+Test Sponsor 1
+Latency: 100 ms, Download: 8 Kbps, Upload: 18.67 Kbps
 
 Try 'NetPace --help' for more information.

--- a/src/NetPace.Console.Tests/NetPaceConsoleTests.cs
+++ b/src/NetPace.Console.Tests/NetPaceConsoleTests.cs
@@ -98,6 +98,23 @@ public class NetPaceConsoleTests
     }
 
     [Fact]
+    public async Task Should_Perform_Speed_Test_Latency_Only()
+    {
+        // Given
+        var registrar = new TypeRegistrar();
+        registrar.Register(typeof(ISpeedTestService), typeof(SpeedTestStub));
+        registrar.Register(typeof(IClock), typeof(ClockStub));
+        var app = GetCommandAppTester(registrar);
+
+        // When
+        var result = await app.RunAsync("--no-download", "--no-upload");
+
+        // Then
+        Assert.Equal(0, result.ExitCode);
+        await Verify(result.Output);
+    }
+
+    [Fact]
     public async Task Should_Perform_Speed_Test()
     {
         // Given

--- a/src/NetPace.Console/Commands/SpeedTestCommand.cs
+++ b/src/NetPace.Console/Commands/SpeedTestCommand.cs
@@ -18,11 +18,6 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
             console.WriteLine($"{fastest.Server.Sponsor}");
         }
 
-        if (settings.NoDownload && settings.NoUpload)
-        {
-            return 0;
-        }
-
 
         // Perform speed test
         var (downloadResult, uploadResult) = await PerformSpeedTestAsync(fastest.Server, settings, cancellationToken);
@@ -97,6 +92,14 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
     {
         var downloadResult = new SpeedTestResult();
         var uploadResult = new SpeedTestResult();
+
+
+        if (settings.NoDownload && settings.NoUpload)
+        {
+            // Latency only test - so just return
+            return (downloadResult, uploadResult);
+        }
+
 
         if (settings.CSV || ((settings.Verbosity & Verbosity.Minimal) != 0))
         {

--- a/src/NetPace.Console/Commands/SpeedTestCommand.cs
+++ b/src/NetPace.Console/Commands/SpeedTestCommand.cs
@@ -15,7 +15,7 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
 
         if (!settings.CSV && ((settings.Verbosity & (Verbosity.Normal | Verbosity.Debug)) != 0))
         {
-            console.WriteLine($"{fastest.Server.Sponsor} ({fastest.Latency} ms)");
+            console.WriteLine($"{fastest.Server.Sponsor}");
         }
 
         if (settings.NoDownload && settings.NoUpload)
@@ -37,6 +37,7 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
             console.WriteLine(string.Join(settings.CSVDelimiter, new[]
             {
                 settings.IncludeTimestamp ? "Timestamp" : null,
+                "Latency",
                 !settings.NoDownload ? "Download" : null,
                 !settings.NoUpload ? "Upload" : null
             }.Where(s => !string.IsNullOrEmpty(s))));
@@ -44,6 +45,7 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
             console.WriteLine(string.Join(settings.CSVDelimiter, new[]
             {
                 settings.IncludeTimestamp ? clock.Now.ToString(settings.DateTimeFormat) : null,
+                $"{fastest.Latency} ms",
                 !settings.NoDownload ? downloadResult.GetSpeedString(settings.SpeedUnit, settings.SpeedUnitSystem) : null,
                 !settings.NoUpload ? uploadResult.GetSpeedString(settings.SpeedUnit, settings.SpeedUnitSystem) : null
             }.Where(s => !string.IsNullOrEmpty(s))));
@@ -73,9 +75,10 @@ public sealed class SpeedTestCommand(IAnsiConsole console, ISpeedTestService spe
 
 
         // Display speed test result
-        console.WriteLine(string.Join(" ", new[]
+        console.WriteLine(string.Join(", ", new[]
         {
             settings.IncludeTimestamp ? clock.Now.ToString(settings.DateTimeFormat) : null,
+            $"Latency: {fastest.Latency} ms",
             !settings.NoDownload ? $"Download: {downloadResult.GetSpeedString(settings.SpeedUnit, settings.SpeedUnitSystem)}" : null,
             !settings.NoUpload ? $"Upload: {uploadResult.GetSpeedString(settings.SpeedUnit, settings.SpeedUnitSystem)}" : null
         }.Where(s => !string.IsNullOrEmpty(s))));

--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.cs
@@ -502,7 +502,7 @@ public class OoklaSpeedtestTests
         result.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(0);
         result.BytesProcessed.ShouldBe(4 * 512 * 1024);
         progressReports.ShouldNotBeNull();
-        progressReports.ShouldBe(new[] { 10, 20, 30, 100 });
+        progressReports.ShouldBe(new[] { 25, 50, 75, 100 });
     }
 
     [Fact]
@@ -727,7 +727,7 @@ public class OoklaSpeedtestTests
         result.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(0);
         result.BytesProcessed.ShouldBe(4 * 512 * 1024);
         progressReports.ShouldNotBeNull();
-        progressReports.ShouldBe(new[] { 10, 20, 30, 100 });
+        progressReports.ShouldBe(new[] { 25, 50, 75, 100 });
     }
 
     [Fact]

--- a/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
+++ b/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
@@ -258,6 +258,20 @@ public sealed class OoklaSpeedtest : ISpeedTestService
                         {
                             // Update the completion percentage.
                             var percentageComplete = (int)((double)completedCount / totalCount * 100);
+
+                            if (maxBytes != long.MaxValue)
+                            {
+                                // When a user specified limit has been imposed on the test,
+                                // we should defer to the greater % complete value.
+
+                                var percentageCompleteMaxBytes = (int)((double)totalBytesReturned / maxBytes * 100);
+
+                                if (percentageCompleteMaxBytes > percentageComplete)
+                                {
+                                    percentageComplete = percentageCompleteMaxBytes;
+                                }
+                            }
+
                             UpdateProgress(new SpeedTestProgress { PercentageComplete = percentageComplete });
                         }
                     }


### PR DESCRIPTION
* More accurate % complete calculations when payload limits are in play.

* Include latency in the file result line; remove latency from brackets after the server name

* Supports latency only speed tests