### PR TITLE
Potential fix for code scanning alert no. 36: Possible loss of precision

### DIFF
--- a/src/NetPace.Core/SpeedTestResultExtensions.cs
+++ b/src/NetPace.Core/SpeedTestResultExtensions.cs
@@ -17,7 +17,7 @@ public static class SpeedTestResultExtensions
         double divisor = unitSystem == SpeedUnitSystem.IEC ? 1024 : 1000;
 
         var speed = isBits
-            ? result.BytesProcessed * 8 / ((double)result.ElapsedMilliseconds / 1000)
+            ? result.BytesProcessed * 8.0 / ((double)result.ElapsedMilliseconds / 1000)
             : result.BytesProcessed / ((double)result.ElapsedMilliseconds / 1000);
 
         return FormatSpeed(speed, isBits, unitSystem, divisor);


### PR DESCRIPTION
Potential fix for [https://github.com/FrankRay78/NetPace/security/code-scanning/36](https://github.com/FrankRay78/NetPace/security/code-scanning/36)

The problem is that integer multiplication is performed before being cast to a double, which risks overflow for large values of `result.BytesProcessed`. The best and most minimal fix is to explicitly cast one of the operands to `double` before multiplication. This will cause the multiplication and subsequent division to be done using floating-point arithmetic, eliminating both overflow and unintentional integer division. In `src/NetPace.Core/SpeedTestResultExtensions.cs`, on line 20, change `result.BytesProcessed * 8` to `result.BytesProcessed * 8.0` (or `(double)result.BytesProcessed * 8`) to force floating-point math for this calculation. No new imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
