### PR TITLE
Fix: framework-dependent release binaries incorrectly bundling .NET runtime since 0.16.0

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -95,6 +95,22 @@ jobs:
         with:
           path: ./artifacts
 
+      - name: Verify framework-dependent binaries are smaller than standalone
+        run: |
+          failed=false
+          for runtime in win-x64 win-arm64 linux-x64 linux-arm64 osx-x64 osx-arm64; do
+            net8=$(find ./artifacts/netpace-$runtime-framework-dependent -type f | head -1)
+            standalone=$(find ./artifacts/netpace-$runtime-self-contained -type f | head -1)
+            net8_size=$(stat -c%s "$net8")
+            standalone_size=$(stat -c%s "$standalone")
+            echo "$runtime: net8=${net8_size} bytes, standalone=${standalone_size} bytes"
+            if [ "$net8_size" -ge "$standalone_size" ]; then
+              echo "FAIL: $runtime net8 (${net8_size}) is not smaller than standalone (${standalone_size})"
+              failed=true
+            fi
+          done
+          if [ "$failed" = "true" ]; then exit 1; fi
+
       - name: Attach binaries to existing release
         uses: softprops/action-gh-release@v1
         with:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="[4.14.1, )">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Removes `runtime` from `IncludeAssets` for `Roslynator.Analyzers` in both `Directory.Build.props` and `Directory.Packages.props`
- Fixes release binaries from 0.16.0 onwards where the framework-dependent (`-net8`) assets were the same size as standalone (~30 MB), because `runtime` in `IncludeAssets` was causing `dotnet publish` to ignore `--self-contained false` and bundle the .NET runtime anyway

## Root cause

Commit `be358a0` introduced `Roslynator.Analyzers` into `Directory.Build.props` (which applies to all projects including `NetPace.Console`) with this asset configuration:

```xml
<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
```

`runtime` is the correct asset type for packages that ship runtime DLLs in a `lib/` folder — but `Roslynator.Analyzers` is an analyzer-only package with no `lib/` folder. Including `runtime` in `IncludeAssets` on a `Directory.Build.props` `PackageReference` interacts with the .NET 8 publish pipeline and causes single-file framework-dependent publishes to behave as self-contained, even when `--self-contained false` is explicitly passed in the workflow.

The correct `IncludeAssets` for a pure analyzer package excludes both `compile` and `runtime`.

## Evidence

| Asset | 0.15.0 | 0.16.0 |
|-------|--------|--------|
| `linux-x64-net8` | 928 KB ✅ | 30 MB ❌ |
| `linux-x64-standalone` | 30 MB | 30 MB |

For `win-x64` and `osx-x64` in 0.16.0+, the net8 and standalone assets are byte-for-byte identical.

## Test plan

- [ ] Trigger a release build (or run the release workflow manually) and verify the `-net8` assets are significantly smaller than `-standalone` (~1 MB vs ~30 MB)
- [ ] Confirm `dotnet build` still succeeds (Roslynator analysis still active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)