### PR TITLE
Move AOT WarningsAsErrors into project file

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -72,8 +72,7 @@ jobs:
               -p:InformationalVersion=${{ steps.get_version.outputs.version }} \
               -p:SelfContained=${{ steps.deployment_flags.outputs.self_contained }} \
               -p:PublishAot=true \
-              -p:InvariantGlobalization=true \
-              "-p:WarningsAsErrors=IL2026;IL2090;IL3050;IL3056"
+              -p:InvariantGlobalization=true
           else
             dotnet publish src/NetPace.Console/NetPace.Console.csproj \
               --configuration Release \

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -9,6 +9,10 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <WarningsAsErrors>IL2026;IL2090;IL3050;IL3056</WarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />


### PR DESCRIPTION
## Summary

Moves the AOT trim/analyzer warnings-as-errors (`IL2026;IL2090;IL3050;IL3056`) out of the `release-binaries.yml` `dotnet publish` command line and into `NetPace.Console.csproj`, gated on `PublishAot=true`. Keeps AOT-warning enforcement co-located with the project that owns AOT compatibility, drops a fragile quoted MSBuild argument from the workflow, and ensures local AOT publishes get the same warning-as-error treatment as CI.

## Spec

N/A

## Changed Files

- .github/workflows/release-binaries.yml
- src/NetPace.Console/NetPace.Console.csproj

nb. This PR is still trying to fix: https://github.com/FrankRay78/NetPace/pull/185