### PR TITLE
Fix AOT smoke test: lowercase AssemblyName + update RELEASING.md

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -114,8 +114,8 @@ jobs:
           smoke_dir="$(mktemp -d)"
           tar -xzf "$archive" -C "$smoke_dir"
           cd "$smoke_dir"
-          ./netpace --version
-          ./netpace --help
+          ./NetPace --version
+          ./NetPace --help
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,11 +39,11 @@ Native AOT cannot be cross-compiled across operating systems — `dotnet publish
 Each AOT matrix entry runs two local-only commands against the freshly extracted archive on its native runner. Both MUST exit `0` for the matrix job to succeed; non-zero exit aborts the release.
 
 ```bash
-./netpace --version
-./netpace --help
+./NetPace --version
+./NetPace --help
 ```
 
-The AOT binary is named `netpace` (lowercase) because `AssemblyName` is overridden to `netpace` inside the `Condition="'$(PublishAot)' == 'true'"` PropertyGroup in `NetPace.Console.csproj`. Non-AOT builds (self-contained, framework-dependent) use the default `NetPace` name (`NetPace.exe` on Windows).
+The AOT binary is named `NetPace` (same as all other variants). On Windows the binary is `NetPace.exe`; on Linux/macOS it is `NetPace`.
 
 ## Size-assertion contract
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,6 +43,8 @@ Each AOT matrix entry runs two local-only commands against the freshly extracted
 ./netpace --help
 ```
 
+The AOT binary is named `netpace` (lowercase) because `AssemblyName` is overridden to `netpace` inside the `Condition="'$(PublishAot)' == 'true'"` PropertyGroup in `NetPace.Console.csproj`. Non-AOT builds (self-contained, framework-dependent) use the default `NetPace` name (`NetPace.exe` on Windows).
+
 ## Size-assertion contract
 
 The `attach-to-release` job validates two relative size invariants before attaching any archive to the release:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -55,7 +55,7 @@ Either invariant failing fails the entire release job; no archives are attached.
 ## Build-time AOT gating
 
 - `<IsAotCompatible>true</IsAotCompatible>` is declared in both `src/NetPace.Core/NetPace.Core.csproj` and `src/NetPace.Console/NetPace.Console.csproj`. This activates the AOT/trim analyzers continuously during `dotnet build` and surfaces `IL2026`/`IL2090`/`IL3050`/`IL3056` warnings at compile time, not just at publish time.
-- AOT publishes additionally pass `-p:WarningsAsErrors=IL2026,IL2090,IL3050,IL3056` and `-p:InvariantGlobalization=true`. `-p:PublishSingleFile=true` is **not** passed for AOT — native AOT already produces a single executable.
+- AOT publishes set `PublishAot=true`, which activates a conditional `<WarningsAsErrors>IL2026;IL2090;IL3050;IL3056</WarningsAsErrors>` block in `NetPace.Console.csproj`. The workflow also passes `-p:InvariantGlobalization=true`. `-p:PublishSingleFile=true` is **not** passed for AOT — native AOT already produces a single executable.
 - `<PublishAot>` is **never** set as a static property in any csproj. AOT is opt-in via the workflow's `-p:PublishAot=true` flag; dev-machine builds remain non-AOT.
 
 ## NuGet metadata

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
-    <AssemblyName>netpace</AssemblyName>
     <WarningsAsErrors>IL2026;IL2090;IL3050;IL3056</WarningsAsErrors>
   </PropertyGroup>
 

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyName>NetPace</AssemblyName>
+    <AssemblyName>netpace</AssemblyName>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -5,11 +5,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyName>netpace</AssemblyName>
+    <AssemblyName>NetPace</AssemblyName>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <AssemblyName>netpace</AssemblyName>
     <WarningsAsErrors>IL2026;IL2090;IL3050;IL3056</WarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes the AOT smoke test failure introduced when the binary name case mismatched the smoke test expectation, and updates RELEASING.md to reflect the WarningsAsErrors move from PR #187.

Related: #187

Generated with [Claude Code](https://claude.ai/code)