### PR TITLE
Win AOT Release

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,7 +61,9 @@
       "mcp__plugin_context-mode_context-mode__ctx_execute_file",
       "Bash(rtk gh *)",
       "Bash(powershell -ExecutionPolicy Bypass -File .specify/scripts/powershell/update-agent-context.ps1 -AgentType claude)",
-      "Bash(powershell -ExecutionPolicy Bypass -File .specify/scripts/powershell/check-prerequisites.ps1 -Json)"
+      "Bash(powershell -ExecutionPolicy Bypass -File .specify/scripts/powershell/check-prerequisites.ps1 -Json)",
+      "Bash(pwsh -NoProfile -Command \".specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks\")",
+      "Bash(pwsh -NoProfile -File .specify/extensions/git/scripts/powershell/auto-commit.ps1 before_implement)"
     ],
     "deny": [
       "Bash(sudo:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,7 +59,9 @@
       "mcp__plugin_context-mode_context-mode__ctx_fetch_and_index",
       "mcp__plugin_context-mode_context-mode__ctx_search",
       "mcp__plugin_context-mode_context-mode__ctx_execute_file",
-      "Bash(rtk gh *)"
+      "Bash(rtk gh *)",
+      "Bash(powershell -ExecutionPolicy Bypass -File .specify/scripts/powershell/update-agent-context.ps1 -AgentType claude)",
+      "Bash(powershell -ExecutionPolicy Bypass -File .specify/scripts/powershell/check-prerequisites.ps1 -Json)"
     ],
     "deny": [
       "Bash(sudo:*)",

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -25,6 +25,20 @@ jobs:
             publish_aot: true
             publish_single_file: false
             invariant_globalization: true
+          - runtime: win-x64
+            deployment: aot
+            runs_on: windows-latest
+            publish_aot: true
+            publish_single_file: false
+            invariant_globalization: true
+          # windows-11-arm runner is GA (April 2025) and free for public repos. Native ARM64 host preserves the
+          # same-job smoke test; cross-compile from windows-latest is rejected — see docs/RELEASING.md §Runner per RID.
+          - runtime: win-arm64
+            deployment: aot
+            runs_on: windows-11-arm
+            publish_aot: true
+            publish_single_file: false
+            invariant_globalization: true
 
     steps:
       - name: Checkout code
@@ -97,10 +111,15 @@ jobs:
             -p:InformationalVersion=${{ steps.get_version.outputs.version }}
 
       - name: Create archive
+        shell: bash
         run: |
           set -euo pipefail
           cd ./publish/${{ matrix.runtime }}-${{ matrix.deployment }}
           if [[ "${{ matrix.runtime }}" == win-* ]]; then
+            if [ "${{ matrix.deployment }}" = "aot" ]; then
+              # Strip debug symbols from Windows AOT archives — release contract: archive contains only NetPace.exe.
+              rm -f ./*.pdb
+            fi
             zip -r ../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}.zip .
           else
             tar -czf ../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}.tar.gz .
@@ -108,14 +127,23 @@ jobs:
 
       - name: Smoke test (AOT only)
         if: matrix.deployment == 'aot'
+        shell: bash
         run: |
           set -euo pipefail
-          archive="netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}-aot.tar.gz"
           smoke_dir="$(mktemp -d)"
-          tar -xzf "$archive" -C "$smoke_dir"
-          cd "$smoke_dir"
-          ./NetPace --version
-          ./NetPace --help
+          if [[ "${{ matrix.runtime }}" == win-* ]]; then
+            archive="netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}-aot.zip"
+            unzip -q "$archive" -d "$smoke_dir"
+            cd "$smoke_dir"
+            ./NetPace.exe --version
+            ./NetPace.exe --help
+          else
+            archive="netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}-aot.tar.gz"
+            tar -xzf "$archive" -C "$smoke_dir"
+            cd "$smoke_dir"
+            ./NetPace --version
+            ./NetPace --help
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -154,8 +182,8 @@ jobs:
             fi
             standalone_size=$(stat -c%s "$standalone")
             for variant in framework-dependent aot; do
-              # AOT variant exists for Linux RIDs only
-              if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* ]]; then continue; fi
+              # AOT variant exists for Linux and Windows RIDs only (macOS AOT is out of scope)
+              if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* && "$runtime" != win-* ]]; then continue; fi
               target=$(find "./artifacts/netpace-$runtime-$variant" -type f 2>/dev/null | head -1 || true)
               if [ -z "$target" ]; then
                 echo "FAIL: $variant artifact missing for $runtime"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -40,6 +40,10 @@ jobs:
             publish_single_file: false
             invariant_globalization: true
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,6 +44,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Verify runner matches runtime (AOT only)
+        if: matrix.deployment == 'aot'
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.runtime }}" in
+            win-*)   expected="Windows" ;;
+            linux-*) expected="Linux" ;;
+            osx-*)   expected="macOS" ;;
+            *)       echo "Unknown runtime prefix: ${{ matrix.runtime }}"; exit 1 ;;
+          esac
+          if [ "$RUNNER_OS" != "$expected" ]; then
+            echo "FAIL: AOT runtime ${{ matrix.runtime }} requires runner OS '$expected', got '$RUNNER_OS'."
+            echo "A typo in matrix.include[*].runs_on would silently fall back to ubuntu-latest — guard catches that."
+            exit 1
+          fi
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -110,6 +127,7 @@ jobs:
             -p:FileVersion=${{ steps.get_version.outputs.version }} \
             -p:InformationalVersion=${{ steps.get_version.outputs.version }}
 
+      # shell: bash forces Git Bash on the Windows runners so the same script (zip vs tar, glob branching) runs uniformly across all matrix entries.
       - name: Create archive
         shell: bash
         run: |
@@ -125,6 +143,27 @@ jobs:
             tar -czf ../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}.tar.gz .
           fi
 
+      - name: Verify archive contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive_stem="netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}"
+          if [[ "${{ matrix.runtime }}" == win-* ]]; then
+            listing=$(unzip -Z1 "${archive_stem}.zip")
+          else
+            listing=$(tar -tzf "${archive_stem}.tar.gz")
+          fi
+          echo "Archive contents:"
+          echo "$listing"
+          # Every release archive contains exactly one entry — the executable.
+          # AOT: native single binary. Non-AOT: PublishSingleFile=true bundle. DebugType=embedded suppresses side .pdb files.
+          entries=$(echo "$listing" | grep -vE '/$' | grep -c . || true)
+          if [ "$entries" -ne 1 ]; then
+            echo "FAIL: archive ${archive_stem} must contain exactly 1 entry, found $entries"
+            exit 1
+          fi
+
+      # shell: bash forces Git Bash on the Windows runners so the unzip/tar branching reuses one script across Linux + Windows AOT entries.
       - name: Smoke test (AOT only)
         if: matrix.deployment == 'aot'
         shell: bash

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-linux-aot-release"
+  "feature_directory": "specs/002-win-aot-release"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-﻿# NetPace Development Guide
+# NetPace Development Guide
 
 ## Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# NetPace Development Guide
+﻿# NetPace Development Guide
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ I am no longer the `Spectre.Console` CLI sub-system maintainer, but this project
 ## Getting Started
 Each release contains precompiled binaries you can simply [download](https://github.com/FrankRay78/NetPace/releases), unzip and run. 
 
-Choose from Windows, Linux and macOS; standalone (large file but includes all dependencies), net8 (small file but requires [Microsoft .NET 8.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)) to already be installed, or AOT compiled for bare metal execution (Linux only). 
+Choose from Windows, Linux and macOS; standalone (large file but includes all dependencies), net8 (small file but requires [Microsoft .NET 8.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)) to already be installed, or AOT compiled for bare metal execution (Linux and Windows; macOS AOT remains a future release). 
 
 Alternatively, clone this repository locally and build.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,7 +4,7 @@ This document describes the release pipeline that builds and attaches downloadab
 
 ## Release matrix
 
-Each tag produces **16 archives** — 12 pre-existing variants plus 4 Native AOT variants (Linux x64/arm64, Windows x64/arm64).
+Each tag produces one archive per cell of the matrix below — currently 16 (4 Native AOT plus 12 non-AOT).
 
 | Runtime ID | Self-contained | Framework-dependent | Native AOT |
 |------------|----------------|---------------------|------------|
@@ -46,6 +46,17 @@ Each AOT matrix entry runs two local-only commands against the freshly extracted
 ```
 
 The AOT binary is named `NetPace` (same as all other variants). On Windows the binary is `NetPace.exe`; on Linux/macOS it is `NetPace`.
+
+## Archive-contents contract
+
+Every release archive contains **exactly one entry** — the executable. A "Verify archive contents" workflow step asserts this on every archive before upload; non-zero exit aborts the release.
+
+How each variant satisfies the contract:
+
+- **Non-AOT (standalone, net8)** — `-p:PublishSingleFile=true` bundles managed assemblies, runtime config, and native libraries into the host executable. `<DebugType>embedded</DebugType>` in both `NetPace.Console.csproj` and `NetPace.Core.csproj` embeds portable PDBs inside the assembly so no managed `.pdb` side file is produced.
+- **AOT** — native AOT produces a single native binary by design. The Windows linker emits a `.pdb` side file regardless of `DebugType`; the Create archive step scrubs `*.pdb` before zipping. Linux AOT debug info is embedded in the ELF.
+
+End-user CLI binaries don't ship symbols — maintainers reproduce locally with their own debug build. If customer crash-dump symbolication is ever needed, push symbols to a workflow artefact rather than into the user-facing archive.
 
 ## Size-assertion contract
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,12 +4,12 @@ This document describes the release pipeline that builds and attaches downloadab
 
 ## Release matrix
 
-Each tag produces **14 archives** — 12 pre-existing variants plus 2 new Linux Native AOT variants.
+Each tag produces **16 archives** — 12 pre-existing variants plus 4 Native AOT variants (Linux x64/arm64, Windows x64/arm64).
 
 | Runtime ID | Self-contained | Framework-dependent | Native AOT |
 |------------|----------------|---------------------|------------|
-| `win-x64` | `netpace-{ver}-win-x64-standalone.zip` | `netpace-{ver}-win-x64-net8.zip` | _(out of scope)_ |
-| `win-arm64` | `netpace-{ver}-win-arm64-standalone.zip` | `netpace-{ver}-win-arm64-net8.zip` | _(out of scope)_ |
+| `win-x64` | `netpace-{ver}-win-x64-standalone.zip` | `netpace-{ver}-win-x64-net8.zip` | `netpace-{ver}-win-x64-aot.zip` |
+| `win-arm64` | `netpace-{ver}-win-arm64-standalone.zip` | `netpace-{ver}-win-arm64-net8.zip` | `netpace-{ver}-win-arm64-aot.zip` |
 | `linux-x64` | `netpace-{ver}-linux-x64-standalone.tar.gz` | `netpace-{ver}-linux-x64-net8.tar.gz` | `netpace-{ver}-linux-x64-aot.tar.gz` |
 | `linux-arm64` | `netpace-{ver}-linux-arm64-standalone.tar.gz` | `netpace-{ver}-linux-arm64-net8.tar.gz` | `netpace-{ver}-linux-arm64-aot.tar.gz` |
 | `osx-x64` | `netpace-{ver}-osx-x64-standalone.tar.gz` | `netpace-{ver}-osx-x64-net8.tar.gz` | _(out of scope)_ |
@@ -31,8 +31,10 @@ Each tag produces **14 archives** — 12 pre-existing variants plus 2 new Linux 
 | All non-AOT entries | `ubuntu-latest` | Cross-compiles fine for non-AOT publishes; matches pre-feature behaviour. |
 | `linux-x64-aot` | `ubuntu-latest` | Native x64 host — no cross-compile toolchain needed. |
 | `linux-arm64-aot` | `ubuntu-24.04-arm` | Native ARM64 host — AOT cross-compilation is fragile, smoke test must run natively. GitHub-hosted ARM64 runners became free for public repos in January 2025. |
+| `win-x64-aot` | `windows-latest` | Native x64 host — no cross-compile toolchain needed; `windows-latest` ships MSVC v143 and the Windows 11 SDK pre-installed. |
+| `win-arm64-aot` | `windows-11-arm` | Native ARM64 host — AOT cross-compilation across architectures is fragile, smoke test must run natively. `windows-11-arm` runners became free for public repos in April 2025. |
 
-Native AOT cannot be cross-compiled across operating systems — `dotnet publish` errors out with `Cross-OS native compilation is not supported`. Hence the per-RID native runners.
+Native AOT cannot be cross-compiled across operating systems — `dotnet publish` errors out with `Cross-OS native compilation is not supported`. Hence the per-RID native runners on both Linux and Windows.
 
 ## Smoke-test contract (AOT only)
 
@@ -50,7 +52,7 @@ The AOT binary is named `NetPace` (same as all other variants). On Windows the b
 The `attach-to-release` job validates two relative size invariants before attaching any archive to the release:
 
 1. For every RID: `framework-dependent < self-contained` (existing pre-feature check).
-2. For Linux x64 and arm64: `aot < self-contained`.
+2. For Linux x64/arm64 and Windows x64/arm64: `aot < self-contained`.
 
 Either invariant failing fails the entire release job; no archives are attached.
 

--- a/docs/change-intent-records/2026-05-02-linux-native-aot-release.md
+++ b/docs/change-intent-records/2026-05-02-linux-native-aot-release.md
@@ -42,6 +42,6 @@
 
 5. **Per-RID relative size assertion (`aot < standalone`)** rather than absolute thresholds — mirrors the existing `framework-dependent < self-contained` check; no maintenance burden as .NET evolves.
 
-6. **No support for cross-OS native compilation** — local AOT validation on a Windows dev box is acknowledged as out of scope; CI's native runners are the validation gate (smoke tests + size assertion).
+6. **No support for cross-OS native compilation** — local AOT validation on a Windows dev box is acknowledged as out of scope; CI's native runners are the validation gate (smoke tests + size assertion). _(Note: this CIR is scoped to Linux AOT only. Windows AOT — `win-x64-aot` and `win-arm64-aot` — is added later under [`specs/002-win-aot-release/`](../../specs/002-win-aot-release/); the cross-OS-cannot-cross-compile rationale carried over unchanged.)_
 
 **Date:** 2026-05-02

--- a/docs/change-intent-records/2026-05-02-linux-native-aot-release.md
+++ b/docs/change-intent-records/2026-05-02-linux-native-aot-release.md
@@ -42,6 +42,6 @@
 
 5. **Per-RID relative size assertion (`aot < standalone`)** rather than absolute thresholds — mirrors the existing `framework-dependent < self-contained` check; no maintenance burden as .NET evolves.
 
-6. **No support for cross-OS native compilation** — local AOT validation on a Windows dev box is acknowledged as out of scope; CI's native runners are the validation gate (smoke tests + size assertion). _(Note: this CIR is scoped to Linux AOT only. Windows AOT — `win-x64-aot` and `win-arm64-aot` — is added later under [`specs/002-win-aot-release/`](../../specs/002-win-aot-release/); the cross-OS-cannot-cross-compile rationale carried over unchanged.)_
+6. **No support for cross-OS native compilation** — local AOT validation on a Windows dev box is acknowledged as out of scope; CI's native runners are the validation gate (smoke tests + size assertion). _(Note: this CIR is scoped to Linux AOT only. Windows AOT — `win-x64-aot` and `win-arm64-aot` — is added later under `specs/002-win-aot-release/`; the cross-OS-cannot-cross-compile rationale carried over unchanged.)_
 
 **Date:** 2026-05-02

--- a/specs/002-win-aot-release/checklists/requirements.md
+++ b/specs/002-win-aot-release/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Windows Native AOT Release Artifacts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Implementation specifics (workflow YAML structure, exact `matrix.include` rows, MSVC version, archive-step `if` branches) intentionally excluded from spec — they belong to `/speckit.plan`. The spec calls out *what* must hold (single `netpace.exe`, no `.pdb`, native runner, two-command smoke test) without prescribing *how*.
+- `CHANGELOG.md` deliberately omitted from FR-010 per Confirmed Decisions in #177 and project memory: per-release notes are GitHub-auto-generated.
+- Two RID-specific Windows runners (`windows-latest`, `windows-11-arm`) and the rejection of cross-compile are framed as constraints/assumptions traceable to `docs/RELEASING.md` and #177 Confirmed Decisions, rather than as design choices made by this spec.

--- a/specs/002-win-aot-release/contracts/release-matrix.md
+++ b/specs/002-win-aot-release/contracts/release-matrix.md
@@ -1,0 +1,75 @@
+# Contract: Release Matrix After Feature 002
+
+**Feature**: 002-win-aot-release
+**Type**: Pipeline-output contract (the public-facing assets a tagged release MUST produce)
+**Date**: 2026-05-10
+
+NetPace exposes no traditional API at the boundary touched by this feature. The "interface" being changed is the **set of release assets attached to each GitHub Release** — i.e. what end users see and download. This file is the binding contract on that surface.
+
+## Inputs
+
+- A semver tag pushed to `main` (e.g. `0.6.0`), no `v` prefix.
+- Source state at that tag, which must include feature 001 (Linux AOT, post-#176) plus this feature (#177).
+
+## Outputs (mandatory, ordered alphabetically)
+
+The GitHub Release MUST have exactly the following 16 assets attached, where `{ver}` is the tag:
+
+```
+netpace-{ver}-linux-arm64-aot.tar.gz
+netpace-{ver}-linux-arm64-net8.tar.gz
+netpace-{ver}-linux-arm64-standalone.tar.gz
+netpace-{ver}-linux-x64-aot.tar.gz
+netpace-{ver}-linux-x64-net8.tar.gz
+netpace-{ver}-linux-x64-standalone.tar.gz
+netpace-{ver}-osx-arm64-net8.tar.gz
+netpace-{ver}-osx-arm64-standalone.tar.gz
+netpace-{ver}-osx-x64-net8.tar.gz
+netpace-{ver}-osx-x64-standalone.tar.gz
+netpace-{ver}-win-arm64-aot.zip            ← new
+netpace-{ver}-win-arm64-net8.zip
+netpace-{ver}-win-arm64-standalone.zip
+netpace-{ver}-win-x64-aot.zip              ← new
+netpace-{ver}-win-x64-net8.zip
+netpace-{ver}-win-x64-standalone.zip
+```
+
+## Per-asset contracts
+
+### `netpace-{ver}-win-x64-aot.zip` (new)
+
+- **Built on**: `windows-latest`.
+- **Archive format**: ZIP.
+- **Contents**: exactly one entry — `NetPace.exe`. No `.dll`, no `.deps.json`, no `.runtimeconfig.json`, no `.pdb`, no other files.
+- **Smoke gate (must pass on the build runner before upload)**: `NetPace.exe --version` exits `0`; `NetPace.exe --help` exits `0`.
+- **Size invariant**: `sizeof(this) < sizeof(netpace-{ver}-win-x64-standalone.zip)`.
+
+### `netpace-{ver}-win-arm64-aot.zip` (new)
+
+- **Built on**: `windows-11-arm`.
+- **Archive format**: ZIP.
+- **Contents**: exactly one entry — `NetPace.exe`. No `.dll`, no `.deps.json`, no `.runtimeconfig.json`, no `.pdb`, no other files.
+- **Smoke gate (must pass on the build runner before upload)**: `NetPace.exe --version` exits `0`; `NetPace.exe --help` exits `0`. Native execution — no x64 emulation.
+- **Size invariant**: `sizeof(this) < sizeof(netpace-{ver}-win-arm64-standalone.zip)`.
+
+### Existing 14 assets (regression contract)
+
+For the same source state, each of the 14 pre-existing assets MUST be byte-identical to the comparable post-#176 release, modulo the tag-version substitution that the publish step performs (`-p:Version=…` etc.) which is unchanged behaviour. No matrix-entry edit, no archive-step edit, and no size-assertion edit may regress any of them.
+
+## Failure modes
+
+If any of the following occur, the `attach-to-release` job MUST NOT publish any asset:
+
+1. Either Windows AOT smoke gate exits non-zero.
+2. The `dotnet publish` for `win-x64-aot` or `win-arm64-aot` exits non-zero (e.g. trim/AOT warning escalated to error).
+3. The `windows-11-arm` runner is unallocatable for the matrix job.
+4. Either Windows AOT archive's size is `≥` its `-standalone` counterpart's size.
+5. The Windows AOT archive contains anything other than the single `NetPace.exe` (verifiable post-implementation by an explicit content check or by hand-inspection on the first post-feature tag).
+
+## Out of contract
+
+- Code signing / Authenticode signature on `NetPace.exe`.
+- `.pdb` distribution.
+- macOS AOT assets (separate future feature).
+- Renaming or removing any existing asset.
+- Behaviour of `NetPace.exe` itself beyond what `--version` / `--help` exercise (covered by the regular xUnit test suite, not this release contract).

--- a/specs/002-win-aot-release/data-model.md
+++ b/specs/002-win-aot-release/data-model.md
@@ -1,0 +1,107 @@
+# Phase 1 Data Model: Windows Native AOT Release Artifacts
+
+**Feature**: 002-win-aot-release
+**Date**: 2026-05-10
+
+This feature ships no source-code changes and therefore no C# domain entities. The "data" of the feature is the **release-pipeline configuration shape** — the rows of the build matrix and the resulting attached release assets. Modelling that shape explicitly catches drift between spec, plan, and tasks.
+
+## Entity 1: Matrix entry
+
+A single row of `jobs.build-cross-platform.strategy.matrix` (either from the base cross-product or from `matrix.include:`).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `runtime` | enum: `win-x64` \| `win-arm64` \| `linux-x64` \| `linux-arm64` \| `osx-x64` \| `osx-arm64` | .NET Runtime Identifier. |
+| `deployment` | enum: `self-contained` \| `framework-dependent` \| `aot` | Variant suffix selector. |
+| `runs_on` | string (GitHub runner image) | Defaults to `ubuntu-latest` via the job-level expression `${{ matrix.runs_on || 'ubuntu-latest' }}`. AOT entries override per R1/R2. |
+| `publish_aot` | bool | Set on AOT entries only; flips the publish step's branch. |
+| `publish_single_file` | bool | `false` for AOT (native AOT is already a single executable); `true` for self-contained / framework-dependent on Linux/macOS, ignored on Windows non-AOT (Windows non-AOT inherits the same `true` value for `PublishSingleFile`). |
+| `invariant_globalization` | bool | `true` for AOT entries. |
+
+### State transitions
+
+A matrix entry has no state — it's static configuration. The pipeline derives a job from each entry.
+
+### New entries for this feature
+
+| `runtime` | `deployment` | `runs_on` | `publish_aot` | `publish_single_file` | `invariant_globalization` |
+|-----------|--------------|-----------|---------------|----------------------|---------------------------|
+| `win-x64` | `aot` | `windows-latest` | `true` | `false` | `true` |
+| `win-arm64` | `aot` | `windows-11-arm` | `true` | `false` | `true` |
+
+Shape is intentionally identical to the existing Linux AOT entries; only `runtime` and `runs_on` differ.
+
+## Entity 2: Release archive
+
+A single archive file attached to the GitHub Release after the `attach-to-release` job runs.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `version` | string (semver, no `v` prefix) | Extracted from the pushed tag via `${GITHUB_REF#refs/tags/}`. |
+| `runtime` | string | Mirrors the matrix entry's `runtime`. |
+| `variant` | enum: `standalone` \| `net8` \| `aot` | Maps from `deployment`: `self-contained → standalone`, `framework-dependent → net8`, `aot → aot`. |
+| `archive_format` | enum: `.zip` \| `.tar.gz` | `.zip` for `runtime` starting `win-`; `.tar.gz` otherwise. |
+| `filename` | string | Computed: `netpace-{version}-{runtime}-{variant}.{archive_format}`. |
+| `contents` | set of file paths inside the archive | Variant-specific (see invariants). |
+
+### Naming invariants
+
+- Filename pattern is fixed by `docs/RELEASING.md` §Naming convention.
+- For `variant = aot`, archive contains the single binary `NetPace` (Linux/macOS) or `NetPace.exe` (Windows). No `.dll`, `.deps.json`, `.runtimeconfig.json`, or `.pdb`.
+- For `variant = standalone`, archive contains the framework-bundled publish output.
+- For `variant = net8`, archive contains the framework-dependent publish output (small; requires .NET 8 runtime on host).
+
+### Size invariant (relative)
+
+For each `runtime` for which both variants exist:
+
+```
+sizeof(net8 archive) < sizeof(standalone archive)
+sizeof(aot archive)  < sizeof(standalone archive)   -- when aot variant exists
+```
+
+Enforced by the `attach-to-release` job's "Verify framework-dependent and AOT binaries are smaller than standalone" step. See R9 — this feature widens the AOT branch of that check from "Linux only" to "Linux + Windows".
+
+### After this feature: 16 archives total
+
+| RID | `standalone` | `net8` | `aot` |
+|-----|--------------|--------|-------|
+| `win-x64` | ✓ | ✓ | **✓ (new)** |
+| `win-arm64` | ✓ | ✓ | **✓ (new)** |
+| `linux-x64` | ✓ | ✓ | ✓ |
+| `linux-arm64` | ✓ | ✓ | ✓ |
+| `osx-x64` | ✓ | ✓ | — |
+| `osx-arm64` | ✓ | ✓ | — |
+
+= 16 archives. Two added; existing 14 unchanged.
+
+## Entity 3: Smoke gate
+
+Per-job step that executes against the freshly-built archive on the matrix entry's runner.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `applies_when` | predicate | `matrix.deployment == 'aot'`. |
+| `commands` | ordered list of two | `./NetPace --version`, `./NetPace --help` (Linux/macOS); `./NetPace.exe --version`, `./NetPace.exe --help` (Windows, via Git Bash `shell: bash`). |
+| `success_predicate` | bool | All commands exit `0`. |
+| `failure_effect` | enum | Fails the matrix job; the dependent `attach-to-release` job does not run; no archives attached. |
+
+### Invariant
+
+Every AOT archive produced by the pipeline is gated by exactly one smoke step on its native runner. Cross-architecture smoke (e.g. running win-arm64 binary on x64 via emulation) is not allowed — explicitly rejected in R2.
+
+## Relationships
+
+```
+Tag pushed
+  ──► Workflow run
+        ├─► For each Matrix entry:
+        │     ├─► Publish step ──produces──► binary
+        │     ├─► Archive step ─wraps────► Release archive
+        │     └─► Smoke step (if aot) ─gates─► Release archive
+        └─► attach-to-release job
+              ├─► Size-assertion step ─validates─► all Release archives
+              └─► Attach step ─publishes─► all Release archives to GitHub Release
+```
+
+This feature adds two new matrix-entry → release-archive paths and widens the size-assertion validation domain to include them.

--- a/specs/002-win-aot-release/plan.md
+++ b/specs/002-win-aot-release/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Windows Native AOT Release Artifacts
+
+**Branch**: `002-win-aot-release` | **Date**: 2026-05-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-win-aot-release/spec.md`
+
+## Summary
+
+Extend the existing release-binaries matrix with two Windows Native AOT entries — `(win-x64, aot, windows-latest)` and `(win-arm64, aot, windows-11-arm)` — reusing the AOT publish flags, smoke-test contract, archive step, and size-assertion contract delivered by feature 001 (Linux AOT, GitHub issue #176). The work is workflow plumbing plus three documentation updates; no production C# changes.
+
+## Technical Context
+
+**Language/Version**: .NET 8.0 / C# 12 (unchanged)
+**Primary Dependencies**: Spectre.Console 0.54.0, System.CommandLine 2.0.1, ByteSize 2.1.2, Microsoft.Extensions.DependencyInjection 9.0.9 (unchanged — already proven AOT-clean by feature 001)
+**Storage**: N/A
+**Testing**: xUnit (existing test projects); release-time smoke gate runs `NetPace.exe --version` / `NetPace.exe --help` on each Windows runner
+**Target Platform**: GitHub Actions release pipeline (`.github/workflows/release-binaries.yml`); end-user targets are Windows x64 and Windows ARM64
+**Project Type**: CLI tool (single project: `NetPace.Console` produces the binary, `NetPace.Core` ships separately on NuGet)
+**Performance Goals**: AOT archive size strictly less than `-standalone` counterpart for the same RID (enforced by existing size-assertion job); end-user cold-start latency parity with the Linux AOT story (sub-50 ms — incidental, not a tracked KPI for this feature)
+**Constraints**:
+  - Native AOT cannot be cross-OS-compiled — `windows-latest` host required for `win-x64`, `windows-11-arm` host required for `win-arm64`.
+  - AOT publishes must keep the existing `WarningsAsErrors=IL2026;IL2090;IL3050;IL3056` clean — no new trim/AOT warnings introduced.
+  - No `.pdb` may leak into the archive (acceptance criterion in the spec).
+  - Existing 14 archive contents must remain byte-identical for the same source state.
+**Scale/Scope**: 2 new matrix entries · 1 workflow file edit · 3 documentation files updated · 0 source files changed.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. TDD (NON-NEGOTIABLE) | PASS — N/A for production code | This feature changes only workflow YAML and documentation. No new production C# code is added; no failing test is required ahead of YAML edits. The release-time smoke step (`--version` / `--help` exit `0`) is itself the test gating the new artefacts, mirroring feature 001. |
+| II. Library-First Architecture | PASS | No `NetPace.Core` API changes. Public surface is unchanged; no new dependency added. |
+| III. CLI Excellence | PASS | No CLI option changes. The two new artefacts expose the existing CLI behaviour; `--help` / `--version` continue to work via the same code path. |
+| IV. Cross-Platform Compatibility | PASS — REINFORCED | This feature *extends* cross-platform support. The AOT/trim warning policy already declared on both projects (`IsAotCompatible=true`) catches platform-divergent reflection at compile time, before the matrix even reaches the new Windows runners. |
+| V. Code Quality Standards | PASS | No production-code edits; the existing zero-warning posture is preserved by the warnings-as-errors block in `NetPace.Console.csproj`. |
+| VI. Minimal Dependencies | PASS | Zero new dependencies. The change is purely workflow + docs. |
+| VII. Semantic Versioning | PASS | No public-API change in `NetPace.Core`; therefore no version bump triggered by this feature itself. The new artefacts ship under whatever semver tag is next pushed. |
+| VIII. AC-to-Test Traceability | PASS — DEFERRED | Acceptance scenarios in `spec.md` will gain `**Scenario:**` labels when `/speckit.testplan` runs and authors `test-plan.md`. The labels live alongside the scenarios; no constitution violation at plan time. |
+
+**Gate result**: PASS. No violations to track in §Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-win-aot-release/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — runner availability, .pdb handling, smoke shell
+├── data-model.md        # Phase 1 output — release archive + matrix-entry schemas
+├── quickstart.md        # Phase 1 output — how to dry-run the extended matrix
+├── contracts/
+│   └── release-matrix.md  # The 16-archive contract this feature must produce
+├── checklists/
+│   └── requirements.md  # Already created by /speckit.specify
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+.github/
+└── workflows/
+    └── release-binaries.yml          # ← edited: 2 new matrix.include entries; archive/smoke steps already handle Windows
+
+src/                                  # ← UNCHANGED
+├── NetPace.Console/
+│   └── NetPace.Console.csproj        # AOT flags already in place (feature 001)
+└── NetPace.Core/
+    └── NetPace.Core.csproj           # IsAotCompatible=true already in place
+
+docs/
+├── RELEASING.md                      # ← edited: matrix table + runner-per-RID table
+└── conventions/                      # unchanged
+
+README.md                             # ← edited: install table grows by 2 rows
+USER_GUIDE.md                         # ← edited: AOT-on-Windows availability note
+```
+
+**Structure Decision**: No new source modules. This feature is a **workflow + documentation patch** layered onto the existing single-project CLI structure. The four files actually edited at implementation time are `.github/workflows/release-binaries.yml`, `docs/RELEASING.md`, `README.md`, and `USER_GUIDE.md`. `CHANGELOG.md` is **not** touched (project has no CHANGELOG; release notes are GitHub-auto-generated — confirmed in `docs/RELEASING.md` §Release notes and project memory).
+
+## Complexity Tracking
+
+> No constitutional violations. Section intentionally empty.

--- a/specs/002-win-aot-release/quickstart.md
+++ b/specs/002-win-aot-release/quickstart.md
@@ -1,0 +1,111 @@
+# Quickstart: Verifying Feature 002 (Windows AOT Release)
+
+**Feature**: 002-win-aot-release
+**Date**: 2026-05-10
+
+This document is the maintainer's runbook for verifying the feature end-to-end. It assumes implementation is complete on `002-win-aot-release` and the branch is being readied for a release-rehearsal tag.
+
+## Prereqs
+
+- Local clone of `FrankRay78/NetPace` on branch `002-win-aot-release` (or a PR branch built on top of it).
+- Local .NET 8 SDK installed.
+- Permission to push tags to the repo (release-rehearsal tag).
+
+## Step 1: Local build sanity check (no Windows-specific path needed yet)
+
+The clean-trim warning policy applies on every `dotnet build`, so any new IL2026 / IL2090 / IL3050 / IL3056 issue introduced anywhere in the codebase fails locally before you ever touch the workflow.
+
+```powershell
+dotnet build
+dotnet test
+```
+
+Both must exit `0` with zero warnings. (Project memory: "Don't commit with failing tests or build warnings.")
+
+## Step 2: Local AOT publish smoke (x64 only — ARM64 requires hardware)
+
+This validates the AOT publish flow that the workflow will run on `windows-latest`. Run from the repo root in PowerShell on a Windows x64 machine:
+
+```powershell
+dotnet publish src/NetPace.Console/NetPace.Console.csproj `
+  --configuration Release `
+  --runtime win-x64 `
+  --self-contained true `
+  --output .\publish\win-x64-aot `
+  -p:PublishAot=true `
+  -p:InvariantGlobalization=true
+```
+
+Expected:
+- Exit code `0`.
+- `.\publish\win-x64-aot\NetPace.exe` exists.
+- Running `.\publish\win-x64-aot\NetPace.exe --version` and `.\publish\win-x64-aot\NetPace.exe --help` both exit `0`.
+- `.\publish\win-x64-aot\NetPace.pdb` also exists in the publish output — this is expected; the **archive** step is responsible for excluding it. Inspecting the staged archive after the workflow runs will confirm the `.pdb` is absent.
+
+If you have a Windows-on-ARM device, repeat with `--runtime win-arm64`. Otherwise rely on the workflow to do this on `windows-11-arm`.
+
+## Step 3: Push a release-rehearsal tag
+
+Use a pre-release semver to avoid polluting the public release stream:
+
+```powershell
+rtk git tag 0.6.0-rc.0
+rtk git push origin 0.6.0-rc.0
+```
+
+Watch the `release-binaries.yml` workflow run. Expected outcome:
+- 16 matrix jobs run; all pass.
+- The `attach-to-release` job runs; size-assertion step passes for all four AOT entries (Linux x64/arm64, Windows x64/arm64).
+- 16 archives attach to the GitHub Release for tag `0.6.0-rc.0`.
+
+## Step 4: Asset-level inspection
+
+Download the two new archives and inspect:
+
+```powershell
+Invoke-WebRequest -Uri "https://github.com/FrankRay78/NetPace/releases/download/0.6.0-rc.0/netpace-0.6.0-rc.0-win-x64-aot.zip" -OutFile .\rehearsal-x64.zip
+Expand-Archive .\rehearsal-x64.zip -DestinationPath .\rehearsal-x64
+Get-ChildItem .\rehearsal-x64
+```
+
+Expected: a single `NetPace.exe`. No `.pdb`, `.dll`, `.deps.json`, or `.runtimeconfig.json`. Run `.\rehearsal-x64\NetPace.exe --version` to confirm end-to-end.
+
+Repeat for `netpace-0.6.0-rc.0-win-arm64-aot.zip` if you have an ARM64 Windows device handy; otherwise rely on the in-job smoke gate.
+
+## Step 5: No-regression check on existing 14 archives
+
+For each of the 14 pre-existing archives, verify content equivalence to a comparable post-#176 release. The simplest hand-check:
+
+```powershell
+# Example for one archive
+$old = "https://github.com/FrankRay78/NetPace/releases/download/{post-176-tag}/netpace-{post-176-tag}-linux-x64-aot.tar.gz"
+$new = "https://github.com/FrankRay78/NetPace/releases/download/0.6.0-rc.0/netpace-0.6.0-rc.0-linux-x64-aot.tar.gz"
+# Extract both, diff the file lists and `dotnet --info` outputs of the binary.
+```
+
+What is allowed to differ: the embedded version string in the binary (assembly metadata reflects the new tag). What must NOT differ: the file list, the binary entry-point, code paths, dependency versions.
+
+## Step 6: Documentation parity check
+
+After the workflow lands and before opening the PR for merge:
+
+- `README.md` install table includes rows for `win-x64-aot.zip` and `win-arm64-aot.zip`.
+- `docs/RELEASING.md` matrix table shows AOT cells filled for `win-x64` and `win-arm64`.
+- `docs/RELEASING.md` runner-per-RID table includes rows for the two Windows AOT entries with their runners (`windows-latest`, `windows-11-arm`) and the rationale (native AOT cannot cross-compile across OS).
+- `USER_GUIDE.md` AOT availability note mentions Windows alongside Linux.
+- `CHANGELOG.md` is **not** edited (project doesn't have one — release notes are GitHub-auto-generated).
+
+## Rollback
+
+If the rehearsal tag fails:
+- Inspect the failing matrix job.
+- Common causes: `windows-11-arm` runner unavailable (re-queue or wait), trim warning regression introduced upstream of this branch (fix in code, retag), `.pdb` slipped into archive (fix archive step, retag).
+- The rehearsal tag can be safely deleted from GitHub if you want to retry with the same number; production tags should never be rewound.
+
+## Done criteria
+
+This feature is verified when:
+1. A release-rehearsal tag (or the next real semver tag) produces 16 archives.
+2. Both new Windows AOT archives pass content + smoke + size invariants.
+3. The 14 pre-existing archives remain identical in shape.
+4. All four documentation files reflect the new artefacts.

--- a/specs/002-win-aot-release/research.md
+++ b/specs/002-win-aot-release/research.md
@@ -1,0 +1,84 @@
+# Phase 0 Research: Windows Native AOT Release Artifacts
+
+**Feature**: 002-win-aot-release
+**Date**: 2026-05-10
+
+This document resolves the open technical questions before implementation begins. The spec already records most decisions as Confirmed Decisions inherited from issue #177; this file captures *why* those decisions stand and what was rejected.
+
+## R1. Runner choice for `win-x64-aot`
+
+- **Decision**: `runs-on: windows-latest`.
+- **Rationale**: Native AOT compilation cannot be performed cross-OS — `dotnet publish -p:PublishAot=true` errors with `Cross-OS native compilation is not supported` when targeting `win-x64` from a non-Windows host. `windows-latest` (Windows Server 2022 at the time of writing) ships with MSVC v143 and the Windows 11 SDK pre-installed; no `setup-msbuild` or `setup-vs` step is required. Same image already used for the existing `win-x64` self-contained / framework-dependent matrix entries — no new image cost.
+- **Alternatives considered**:
+  - *Cross-compile from `ubuntu-latest`* — rejected by the SDK constraint above.
+  - *Docker Windows container on `ubuntu-latest`* — feasible in principle but introduces a new runner image, slower cold-start, and no upside vs. running directly on `windows-latest`.
+
+## R2. Runner choice for `win-arm64-aot`
+
+- **Decision**: `runs-on: windows-11-arm`.
+- **Rationale**: GitHub-hosted Windows-on-ARM runners (`windows-11-arm`) became GA in April 2025 and are free for public repositories — `FrankRay78/NetPace` qualifies. Native ARM64 host preserves the same-job smoke test and matches the runner-per-RID rationale `docs/RELEASING.md` already records for `linux-arm64-aot` (`ubuntu-24.04-arm`).
+- **Alternatives considered**:
+  - *Cross-compile from `windows-latest` (`-r win-arm64`)* — supported by the SDK but loses the ability to smoke-test the binary on its target architecture in the same job. Rejected by Confirmed Decisions in #177; same reasoning as for the Linux ARM64 case.
+  - *Self-hosted ARM64 runner* — adds operational burden; unjustified while the GitHub-hosted runner is free for the repo.
+- **Contingency**: If `windows-11-arm` becomes paywalled or is removed from the free tier, the cross-compile path is the documented fallback. Capturing that as a future issue rather than implementing it now.
+- **Workflow visibility**: The `windows-11-arm` choice and its rationale will be captured as an inline comment on the matrix entry, per FR-011, so future contributors do not reach for cross-compile out of doubt.
+
+## R3. `.pdb` exclusion from the release archive
+
+- **Decision**: Exclude `.pdb` from the Windows AOT archive.
+- **Rationale**: Matches the bare-binary posture of the Linux AOT archives (single `NetPace` executable, nothing else). Symbol publishing — whether via NuGet `.snupkg`, a separate symbol-artefact channel, or attaching `.pdb`s as their own release assets — is its own initiative and explicitly out of scope per #177 §3.
+- **Mechanism**: The `dotnet publish` output for AOT on Windows produces `NetPace.exe` plus `NetPace.pdb` in the publish directory. The archive step must select only the `.exe` (or, equivalently, scrub the `.pdb` before archiving). The current archive step zips the entire publish directory unconditionally — see [`release-binaries.yml:99-107`](../../.github/workflows/release-binaries.yml#L99-L107) — so a one-line scrub (e.g. `rm *.pdb` on Windows runners when `deployment == aot`) is the simplest fit. Implementation detail to be finalised in tasks.
+- **Acceptance**: Archive contents check (FR-003) will fail the release if any `.pdb` slips through.
+
+## R4. Smoke-test shell on Windows runners
+
+- **Decision**: `shell: bash` for the smoke step on Windows AOT entries.
+- **Rationale**: Both `windows-latest` and `windows-11-arm` ship with Git Bash pre-installed. Reusing the same bash smoke logic that already runs on the Linux AOT entries (`./NetPace --version` / `./NetPace --help`) keeps the workflow simple — one branch in the smoke step, not two parallel implementations. The binary on Windows is `NetPace.exe`; bash on Windows runs it identically (`./NetPace.exe --version`). Confirmed in #177 Confirmed Decisions.
+- **Alternatives considered**:
+  - *PowerShell smoke* — would require a parallel implementation, no upside.
+  - *cmd.exe smoke* — same objection.
+
+## R5. Smoke-test depth
+
+- **Decision**: Two commands only — `--version` and `--help`. No `servers`, no retry/timeout wrapper.
+- **Rationale**: Matches the contract locked for Linux AOT in #176 / `docs/RELEASING.md` §Smoke-test contract. The two commands together exercise startup, AOT-trimmed reflection paths used by `System.CommandLine` parsing, and console rendering by Spectre.Console — sufficient to catch the AOT-specific failure modes (missing trim metadata, broken globalization, native-image init crash) without making the smoke step a network-dependent integration test. Broader smoke enhancements belong in a separate cross-cutting issue; doing them here would expand scope.
+- **Alternatives considered**:
+  - *Add `servers`* — calls Ookla servers list endpoint, network-dependent, flaky on shared runners. Rejected.
+  - *Add a deliberate-failure check (`netpace.exe --bogus-flag`) to verify exit-code propagation* — unnecessary; covered by existing test suite.
+
+## R6. Globalization mode for AOT
+
+- **Decision**: `-p:InvariantGlobalization=true`, identical to Linux AOT.
+- **Rationale**: Already wired into the AOT branch of the publish step (see [`release-binaries.yml:74-75`](../../.github/workflows/release-binaries.yml#L74-L75)). Windows divergence would be unjustified — none of NetPace's user-facing output requires culture-aware formatting that wouldn't already work under invariant culture. Avoids dragging the ICU data files into the AOT publish.
+
+## R7. Archive format on Windows
+
+- **Decision**: `.zip` (already produced by the existing `if [[ "${{ matrix.runtime }}" == win-* ]]` branch in the archive step). No change needed.
+- **Rationale**: Convention; matches existing Windows release archives and `docs/RELEASING.md` §Naming convention.
+
+## R8. Preserving the existing 14 archives byte-identical
+
+- **Decision**: The two new matrix entries are added via `matrix.include:` and inherit the deployment shape (`publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`) that already exists for the Linux AOT entries. No edits to any of the six pre-existing `runtime` × `deployment` combinations.
+- **Rationale**: `matrix.include:` extends the matrix without touching the base cross-product. Existing self-contained / framework-dependent jobs run with identical inputs and steps as before; their outputs are byte-identical for the same source state (modulo the version-string substitution from the tag, which is unchanged behaviour).
+- **Verification**: After implementation, on a release-rehearsal tag, hash-compare the existing 14 archives against the comparable post-#176 release. Documented in quickstart.md.
+
+## R9. Size-assertion contract extension
+
+- **Decision**: Extend the existing size-assertion loop to cover Windows AOT — i.e. the `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* ]]; then continue; fi` guard at [`release-binaries.yml:158`](../../.github/workflows/release-binaries.yml#L158) becomes `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* && "$runtime" != win-* ]]; then continue; fi`, or equivalently is rewritten to allow-list the four AOT-bearing RIDs explicitly.
+- **Rationale**: Without this change, the existing assertion would silently skip the new Windows AOT archives, defeating FR-004. Spec says the invariant must be enforced for the new RIDs, so the guard must be widened.
+- **Implementation note**: Whether to widen the negation or rewrite as an explicit allow-list is a tactic for `/speckit.tasks` — both produce the same observable behaviour.
+
+## R10. Trim/AOT warning behaviour on Windows-specific code paths
+
+- **Decision**: Trust the existing `IsAotCompatible=true` static analysis to catch any Windows-specific reflection issue at `dotnet build` time, before the workflow even reaches the new matrix entries.
+- **Rationale**: The clean-trim policy delivered by feature 001 enforces `WarningsAsErrors=IL2026;IL2090;IL3050;IL3056` whenever `PublishAot=true`. Both projects already declare `IsAotCompatible=true`, so the analyzers run on every `dotnet build` regardless of platform, surfacing platform-divergent reflection during ordinary CI long before release. No additional gating needed for Windows.
+- **Risk**: If a Windows-only code path slipped past the analyzers (e.g. a `[DllImport]` to a Windows API used only at runtime under a `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` guard), it could surface as a runtime error in the smoke step. Mitigation: the smoke test is the second line of defence and will fail the release before attach.
+
+## R11. Documentation scope
+
+- **Decision**: Edit `README.md`, `docs/RELEASING.md`, and `USER_GUIDE.md`. Do **not** create or touch `CHANGELOG.md`.
+- **Rationale**: The project has no `CHANGELOG.md`; per-release notes are GitHub-auto-generated from merged PRs (see `docs/RELEASING.md` §Release notes and the explicit Confirmed Decision in #177). Adding one now would be net-new infrastructure outside the feature's scope. Project memory at `.claude/memory/feedback_cli_feature_doc_scope.md` codifies this.
+
+## Summary of resolved unknowns
+
+All `NEEDS CLARIFICATION` items from Technical Context are resolved by R1–R11 above. The plan can proceed to Phase 1 design.

--- a/specs/002-win-aot-release/spec.md
+++ b/specs/002-win-aot-release/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Windows Native AOT Release Artifacts
+
+**Feature Branch**: `002-win-aot-release`
+**Created**: 2026-05-10
+**Status**: Draft
+**Input**: GitHub issue [#177 — Add Windows Native AOT release artifacts (win-x64, win-arm64)](https://github.com/FrankRay78/NetPace/issues/177)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Windows x64 user gets a fast-startup AOT NetPace (Priority: P1)
+
+A Windows desktop or server user on x64 hardware downloads a NetPace release, expects a small archive containing a single native executable that starts instantly with no .NET runtime install required and no JIT warm-up. They unzip, run `netpace.exe --version` to confirm the build, then run a speed test and see results print in the terminal.
+
+**Why this priority**: x64 is overwhelmingly the most common Windows architecture for the NetPace audience (developers, sysadmins, hobbyists). Closing the parity gap with Linux AOT here delivers the bulk of the user-visible benefit and is a precondition for the ARM64 variant.
+
+**Independent Test**: Cut a pre-release tag against a branch with only the `win-x64-aot` matrix entry added; confirm `netpace-{tag}-win-x64-aot.zip` appears on the release, contains a single `netpace.exe`, and runs end-to-end on a clean Windows x64 machine with no .NET runtime installed.
+
+**Acceptance Scenarios**:
+
+1. **Scenario: Win-x64 AOT archive appears on tagged release**
+   **Given** a tagged release after this feature ships, **When** the user visits the GitHub release page, **Then** they see a `netpace-{tag}-win-x64-aot.zip` asset alongside the existing `win-x64-standalone.zip` and `win-x64-net8.zip` assets.
+2. **Scenario: Win-x64 AOT binary runs with no dotnet runtime installed**
+   **Given** the user has downloaded and extracted `netpace-{tag}-win-x64-aot.zip` on a Windows x64 machine with no .NET runtime installed, **When** they run `netpace.exe --version`, **Then** the command prints the version string and exits with code `0`.
+3. **Scenario: Win-x64 AOT archive contains only the netpace.exe**
+   **Given** the same extracted archive, **When** the user inspects its contents, **Then** the only file present is `netpace.exe` — no `.dll`, no `.deps.json`, no `.runtimeconfig.json`, no `.pdb`.
+4. **Scenario: Win-x64 AOT archive is smaller than win-x64 standalone**
+   **Given** the same release tag, **When** the user compares archive sizes, **Then** `netpace-{tag}-win-x64-aot.zip` is materially smaller than `netpace-{tag}-win-x64-standalone.zip`.
+
+---
+
+### User Story 2 - Windows ARM64 user gets a native AOT NetPace (Priority: P2)
+
+A user on a Windows-on-ARM device (Surface Pro X, Snapdragon-based laptop, ARM64 IoT/edge box) downloads a NetPace release, expects a native ARM64 executable rather than an emulated x64 binary. They unzip, run `netpace.exe --version`, and see results without any x64 emulation overhead.
+
+**Why this priority**: Smaller share of the Windows audience than x64 today, but parity matters for the IoT/edge story (the issue is labelled `embedded IOT`) and for the growing class of Windows-on-ARM laptops. Independently shippable from Story 1 — its absence does not block the x64 win.
+
+**Independent Test**: Add only the `win-arm64-aot` matrix entry, push a pre-release tag, confirm `netpace-{tag}-win-arm64-aot.zip` is produced on a `windows-11-arm` runner, contains a single `netpace.exe`, and the same-job smoke test exits `0` natively (not via x64 emulation).
+
+**Acceptance Scenarios**:
+
+1. **Scenario: Win-arm64 AOT archive appears on tagged release**
+   **Given** a tagged release after this feature ships, **When** the user visits the GitHub release page, **Then** they see a `netpace-{tag}-win-arm64-aot.zip` asset.
+2. **Scenario: Win-arm64 AOT binary runs natively on Windows-on-ARM**
+   **Given** the user has extracted `netpace-{tag}-win-arm64-aot.zip` on a Windows ARM64 machine, **When** they run `netpace.exe --version` and `netpace.exe --help`, **Then** both commands exit `0` and print the expected output.
+3. **Scenario: Win-arm64 AOT archive contains only the netpace.exe**
+   **Given** the archive, **When** the user inspects its contents, **Then** the only file present is `netpace.exe` (same single-file shape as the x64 AOT archive).
+
+---
+
+### User Story 3 - Release maintainer trusts the matrix and ships a clean tag (Priority: P3)
+
+A maintainer pushes a semver tag to `main`. They expect the release pipeline to produce 16 archives in total — the existing 14 plus the two new Windows AOT variants — with no regression to the existing 14, and to halt the release before any artefact is attached if either new Windows AOT smoke test fails or a size invariant is violated.
+
+**Why this priority**: Operational confidence rather than direct user value. Necessary to land Stories 1 and 2 safely, but not what the end user downloads. Captures the "no regression" and "fail-fast" guarantees that protect every prior release variant.
+
+**Independent Test**: After Stories 1 and 2 are wired up, run the full release on a release-rehearsal tag and confirm: 16 archives produced, the existing 14 are byte-identical (ignoring tag-string differences) to a comparable post-#176 release, and a deliberately-broken AOT publish fails the matrix job before reaching the attach step.
+
+**Acceptance Scenarios**:
+
+1. **Scenario: Tagged release attaches exactly 16 archives**
+   **Given** a fresh semver tag pushed after this feature ships, **When** the release workflow completes, **Then** exactly 16 archives are attached to the GitHub Release: the 14 from post-#176 plus `netpace-{tag}-win-x64-aot.zip` and `netpace-{tag}-win-arm64-aot.zip`.
+2. **Scenario: Existing 14 archives are unchanged versus post-176 release**
+   **Given** the same tag, **When** the maintainer compares the existing 14 archives against a comparable post-#176 release of the same source state, **Then** their contents are unchanged (no regression introduced by the matrix extension).
+3. **Scenario: Failing Windows AOT smoke test halts release attach**
+   **Given** a tag where the Windows AOT smoke test deliberately fails (e.g. a forced non-zero exit), **When** the workflow runs, **Then** the release attach step does not execute and no archives are published.
+4. **Scenario: Windows AOT size invariant violation halts release attach**
+   **Given** a tag where the Windows AOT archive is larger than its `-standalone` counterpart (size invariant violated), **When** the workflow runs, **Then** the release attach step does not execute.
+5. **Scenario: RELEASING.md documents win-arm64 runner choice**
+   **Given** the merged feature, **When** a future contributor reads `docs/RELEASING.md`, **Then** they find the Windows AOT rows in the release matrix, the `windows-latest` / `windows-11-arm` runner choices documented, and the rationale for not cross-compiling captured.
+
+---
+
+### Edge Cases
+
+- **`windows-11-arm` runner unavailable / paywalled mid-release**: The `win-arm64-aot` matrix job fails fast; the release attach step does not execute; the maintainer can re-run the tag once availability returns. No automatic fallback to cross-compile (rejected by Confirmed Decisions in #177).
+- **AOT publish surfaces a new IL2026/IL2090/IL3050/IL3056 warning on Windows but not Linux**: The AOT publish exits non-zero (warnings-as-errors), the matrix job fails, the release halts. Resolution is the same as for the Linux AOT path — fix the underlying trim/AOT issue in code.
+- **End user on Windows x64 attempts to run the ARM64 AOT binary (or vice versa)**: Windows refuses to launch the binary with a platform-mismatch error. The user is expected to pick the archive matching their architecture from the release-asset list.
+- **SmartScreen / AV warning on first download**: First-run warning is expected because Windows AOT binaries are unsigned (same posture as the existing `-standalone` Windows builds). Not remediated by this feature; user dismisses the warning. Code-signing is a separate, larger initiative.
+- **Existing user on Windows continues to download `-standalone` or `-net8` archives**: They keep working unchanged. Both legacy variants remain in the release for compatibility; AOT is purely additive.
+- **`.pdb` ends up inside the archive**: Treated as an acceptance-criterion violation — the archive contents check fails the release before attach.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The release pipeline MUST produce a `netpace-{version}-win-x64-aot.zip` archive whenever a semver tag is pushed.
+- **FR-002**: The release pipeline MUST produce a `netpace-{version}-win-arm64-aot.zip` archive whenever a semver tag is pushed.
+- **FR-003**: Each Windows AOT archive MUST contain exactly one file: a native `netpace.exe`. No `.dll`, `.deps.json`, `.runtimeconfig.json`, or `.pdb` companion files are permitted in the archive.
+- **FR-004**: Each Windows AOT archive MUST be materially smaller than its `-standalone` counterpart for the same RID. The release pipeline MUST enforce this size invariant and halt the release if it is violated, mirroring the existing Linux AOT size check.
+- **FR-005**: The release pipeline MUST run a smoke test on each Windows AOT archive on a runner that natively executes the target architecture (`windows-latest` for x64, `windows-11-arm` for ARM64). Cross-compiled smoke tests are not acceptable.
+- **FR-006**: The Windows AOT smoke test MUST execute exactly two commands against the freshly extracted archive — `netpace.exe --version` and `netpace.exe --help` — and MUST require both to exit `0`. (Matches the smoke contract locked for Linux AOT in #176.)
+- **FR-007**: Both Windows AOT publish steps MUST treat the AOT/trim warning codes already configured for AOT (currently `IL2026`, `IL2090`, `IL3050`, `IL3056`) as errors, identical to the Linux AOT path.
+- **FR-008**: The existing 14 release archives (Windows / Linux / macOS self-contained and framework-dependent, plus Linux x64/arm64 AOT) MUST remain byte-identical to a comparable post-#176 release of the same source state. The Windows AOT addition MUST NOT regress any existing variant.
+- **FR-009**: If either Windows AOT matrix job fails — at publish, smoke test, or size-assertion stage — the release attach step MUST NOT execute, mirroring the existing fail-fast posture.
+- **FR-010**: User-facing documentation MUST be updated in lockstep with this feature:
+  - `README.md` install table extended with `win-x64-aot.zip` and `win-arm64-aot.zip` rows.
+  - `docs/RELEASING.md` release matrix and runner-per-RID table extended; the `windows-11-arm` choice for `win-arm64-aot` and the rejection of cross-compile MUST be documented inline.
+  - `USER_GUIDE.md` AOT-vs-standalone-vs-framework-dependent note MUST mention that AOT is now also available for Windows.
+  - `CHANGELOG.md` is **not** in scope — per-release notes are GitHub-auto-generated (per `docs/RELEASING.md` §Release notes).
+- **FR-011**: `windows-11-arm` runner availability for the `FrankRay78/NetPace` public repository MUST be confirmed and that confirmation captured in the workflow (e.g. as a comment on the `win-arm64-aot` matrix entry) so future contributors do not doubt it or reach for cross-compile.
+- **FR-012**: The release-asset count after this feature ships MUST be exactly 16 (the 14 from post-#176 plus the two new Windows AOT archives). No other variant is added or removed by this feature.
+
+### Key Entities
+
+- **Release archive**: A single `.zip` (Windows) or `.tar.gz` (Linux/macOS) attached to a GitHub Release, named per the convention in `docs/RELEASING.md`. The two new entities introduced here are `netpace-{version}-win-x64-aot.zip` and `netpace-{version}-win-arm64-aot.zip`.
+- **Matrix entry**: A row of the release-pipeline build matrix that pairs a Runtime Identifier (RID), a deployment variant (`standalone` / `net8` / `aot`), and a runner image. This feature adds two such rows: `(win-x64, aot, windows-latest)` and `(win-arm64, aot, windows-11-arm)`.
+- **Smoke test**: Two commands (`--version`, `--help`) executed against an extracted archive on its native runner, gating release attachment.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Within one tagged release after this feature merges, the GitHub Release page shows exactly 16 attached archives, including `netpace-{tag}-win-x64-aot.zip` and `netpace-{tag}-win-arm64-aot.zip`.
+- **SC-002**: A Windows x64 user with no .NET runtime installed can download `netpace-{tag}-win-x64-aot.zip`, extract it, and run `netpace.exe --version` successfully — measured by a green smoke-test step on every release tag.
+- **SC-003**: Both Windows AOT archives are smaller than their `-standalone` counterparts (size invariant passes on every release tag — no manual override needed).
+- **SC-004**: The existing 14 release archives remain identical in contents to the comparable post-#176 release for the same source state — verified by a manual diff on the first post-feature tag and by no churn in pre-existing archive consumers' install scripts.
+- **SC-005**: A future contributor reading `docs/RELEASING.md` after this feature ships can identify, in under 60 seconds and without consulting any other document, why `windows-11-arm` is used for `win-arm64-aot` and why cross-compile is not used.
+- **SC-006**: First-time-from-clean release run on a fresh semver tag completes in roughly the same wall-clock time as the comparable post-#176 release, plus the additional time for two Windows AOT matrix jobs in parallel — i.e. the feature does not serialize the matrix or otherwise inflate end-to-end release latency beyond the natural cost of the two new jobs.
+
+## Assumptions
+
+- **Issue #176 has merged before this work begins.** All cross-cutting AOT groundwork — `IsAotCompatible=true` on both projects, the clean-trim warning policy, the `XmlExtensions.cs` rewrite, the Humanizer resolution, the `InvariantGlobalization=true` AOT flag, the matrix-extension pattern, the size-assertion contract, the smoke-test contract — is in place and applies unchanged to Windows. (Confirmed by current `docs/RELEASING.md` showing 14 archives including the two Linux AOT variants.)
+- **Windows runners are the right host for Windows AOT.** `windows-latest` for `win-x64-aot` and `windows-11-arm` for `win-arm64-aot`; no cross-compile from Linux or from `windows-latest` to ARM64. This decision is locked by Confirmed Decisions in #177 and mirrors the Linux runner-per-RID decision in `docs/RELEASING.md`.
+- **`windows-11-arm` runners remain free for public repositories** for the foreseeable future. If GitHub paywalls or removes free ARM64 Windows runners, the `win-arm64-aot` job will fail at the runner-allocation stage; the contingency (cross-compile fallback) is explicitly out of scope and would be its own future issue.
+- **`.pdb` is excluded from the release archive.** End-user crash debugging on bare-binary AOT downloads is acceptable; symbol distribution (NuGet `.snupkg` or a separate symbol channel) is a separate future initiative. Confirmed by Decision in #177 §3.
+- **Unsigned Windows native binaries are acceptable for this release.** SmartScreen warnings on first download are expected; mitigation belongs with a separate code-signing initiative covering all release variants. Confirmed in #177 Out-of-scope.
+- **`-standalone` and `-net8` Windows archives remain indefinitely.** This feature is purely additive; no existing variant is renamed, removed, or deprecated. Future deprecation of `-standalone` is a separate decision once Windows AOT proves itself across two or three releases.
+- **macOS AOT is a separate, later issue.** Out of scope here; no macOS-runner work in this feature.
+- **Smoke-test depth stays at the two-command contract.** No `servers` invocation, no retry/timeout wrapper. Broader smoke enhancements belong in a separate cross-cutting issue. Confirmed in #177 Confirmed Decisions.
+- **Smoke-test shell is `bash`.** Git Bash is pre-installed on both Windows runners; the smoke step uses an `if`-branch for `unzip` vs `tar -xzf` and the binary name is `NetPace.exe` (capitalisation per case-sensitive convention) on Windows. Confirmed in #177 Confirmed Decisions.

--- a/specs/002-win-aot-release/tasks.md
+++ b/specs/002-win-aot-release/tasks.md
@@ -1,0 +1,190 @@
+---
+
+description: "Tasks for feature 002 — Windows Native AOT release artifacts"
+---
+
+# Tasks: Windows Native AOT Release Artifacts
+
+**Input**: Design documents from `specs/002-win-aot-release/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/release-matrix.md](./contracts/release-matrix.md), [quickstart.md](./quickstart.md)
+
+**Tests**: This feature ships **no production C# code**. The "tests" are the release-pipeline smoke gate (`NetPace.exe --version` / `--help` exit `0` on each Windows runner) and the size-assertion job — both delivered by editing the existing workflow, not by writing new test files. Spec-kit task IDs cover those workflow edits, plus the documentation updates and the rehearsal-tag verification.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently. US1 (win-x64-aot) is the MVP; US2 (win-arm64-aot) and US3 (maintainer/16-archive guarantee) follow.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps the task to a user story (US1, US2, US3) for traceability
+- File paths are absolute relative to repo root.
+
+## Path Conventions
+
+This feature edits four files only — `.github/workflows/release-binaries.yml`, `docs/RELEASING.md`, `README.md`, `USER_GUIDE.md` — plus the verification activities in §Phase 5. **No `src/` or `tests/` files are touched.**
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the working tree is clean and the branch is in the expected state.
+
+- [ ] T001 Confirm current branch is `002-win-aot-release` and working tree is clean (`git status` reports no uncommitted changes outside this feature's spec/plan/tasks artefacts) before any workflow edits begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Workflow-shape changes shared by both Windows AOT entries. These edits to `.github/workflows/release-binaries.yml` MUST land before either US1 or US2 can produce a working AOT archive: the smoke step needs to know how to extract a `.zip`, the archive step needs to scrub `.pdb`, and the size-assertion job needs to allow `win-*` AOT through its filter. All three edit the same workflow file and must therefore proceed sequentially, not in parallel.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Update the smoke-test step at `.github/workflows/release-binaries.yml:109-118` to handle Windows archives: branch the extraction on archive format (`unzip` for `*.zip`, existing `tar -xzf` for `*.tar.gz`), and invoke the binary as `./NetPace.exe` on Windows runners (`./NetPace` elsewhere). Keep `shell: bash` (Git Bash ships on both `windows-latest` and `windows-11-arm` per research R4).
+- [ ] T003 Update the archive step at `.github/workflows/release-binaries.yml:99-107` to exclude `*.pdb` from Windows AOT zips: when `matrix.deployment == 'aot'` and `matrix.runtime` matches `win-*`, remove or omit `*.pdb` files before invoking `zip -r`. Linux/macOS branches and Windows non-AOT branches remain unchanged.
+- [ ] T004 Widen the size-assertion guard at `.github/workflows/release-binaries.yml:158` from `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* ]]; then continue; fi` to allow `win-*` AOT entries through (e.g. `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* && "$runtime" != win-* ]]; then continue; fi`, or rewrite as an explicit allow-list of the four AOT-bearing RIDs). Either tactic produces the same observable behaviour per research R9.
+
+**Checkpoint**: Foundational workflow shape is ready. US1 and US2 can now add their matrix entries and have them flow through extract → smoke → size-check correctly.
+
+---
+
+## Phase 3: User Story 1 - Windows x64 user gets a fast-startup AOT NetPace (Priority: P1) 🎯 MVP
+
+**Goal**: Ship `netpace-{tag}-win-x64-aot.zip` on the next semver tag — a single-file native AOT executable that runs on Windows x64 with no .NET runtime installed.
+
+**Independent Test**: After this phase, cut a pre-release tag (e.g. `0.6.0-rc.0`) on a branch with only the US1 changes applied (foundational + the win-x64 matrix entry + US1 doc rows). Confirm the release attaches `netpace-{tag}-win-x64-aot.zip`, that the archive contains a single `NetPace.exe`, and that `NetPace.exe --version` exits `0` on a clean Windows x64 host.
+
+### Implementation for User Story 1
+
+- [ ] T005 [US1] Add the `win-x64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-x64`, `deployment: aot`, `runs_on: windows-latest`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Match the field shape of the existing `linux-x64-aot` entry exactly (data-model.md §Entity 1).
+- [ ] T006 [P] [US1] Add `netpace-{ver}-win-x64-aot.zip` to the install table in `README.md` (alongside the existing `win-x64-standalone.zip` and `win-x64-net8.zip` rows).
+- [ ] T007 [P] [US1] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-x64`, Native AOT) intersection with `netpace-{ver}-win-x64-aot.zip`. Update the table-summary line above ("Each tag produces **14 archives**...") to reflect the new total of 16 (do this once for both Windows entries; if T013 has already been done, skip the count edit here).
+- [ ] T008 [P] [US1] Add a row to `docs/RELEASING.md` §Runner per RID for `win-x64-aot` with runner `windows-latest` and rationale text matching the existing `linux-x64-aot` row's shape ("Native x64 host — no cross-compile toolchain needed; `windows-latest` ships MSVC v143 and the Windows 11 SDK pre-installed.").
+- [ ] T009 [P] [US1] Update `docs/RELEASING.md` §Runner per RID prose paragraph to extend "Native AOT cannot be cross-compiled across operating systems" to explicitly cover Windows ("...hence the per-RID native runners on both Linux and Windows."). One sentence; preserve the existing wording.
+- [ ] T010 [P] [US1] Update the AOT-availability note in `USER_GUIDE.md` to mention Windows alongside Linux ("AOT builds are available for Linux and Windows; macOS AOT remains a future release."). One line edit.
+
+**Checkpoint**: At this point, the release pipeline produces a working `win-x64-aot.zip` on every tag, the size-assertion gate enforces it, and all four user-facing doc files reflect the new artefact. US1 is independently testable via a pre-release tag.
+
+---
+
+## Phase 4: User Story 2 - Windows ARM64 user gets a native AOT NetPace (Priority: P2)
+
+**Goal**: Ship `netpace-{tag}-win-arm64-aot.zip` on the next semver tag — a native ARM64 executable produced on `windows-11-arm`, no x64 emulation.
+
+**Independent Test**: After this phase, cut a pre-release tag on a branch with only the US2 changes applied (foundational + the win-arm64 matrix entry + US2 doc rows). Confirm the release attaches `netpace-{tag}-win-arm64-aot.zip`, that the archive's `NetPace.exe` reports `IMAGE_FILE_MACHINE_ARM64` in its PE header, and that the same-job smoke step on the `windows-11-arm` runner exits `0`.
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Add the `win-arm64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-arm64`, `deployment: aot`, `runs_on: windows-11-arm`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Above the entry, add an inline YAML comment capturing the runner-availability confirmation per FR-011 — wording suggestion: `# windows-11-arm runner is GA (April 2025) and free for public repos. Native ARM64 host preserves the same-job smoke test; cross-compile from windows-latest is rejected — see docs/RELEASING.md §Runner per RID.`
+- [ ] T012 [P] [US2] Add `netpace-{ver}-win-arm64-aot.zip` to the install table in `README.md` (alongside the existing `win-arm64-standalone.zip` and `win-arm64-net8.zip` rows).
+- [ ] T013 [P] [US2] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-arm64`, Native AOT) intersection with `netpace-{ver}-win-arm64-aot.zip`. Update the table-summary line to reflect the new total of 16 archives (skip if already done in T007).
+- [ ] T014 [P] [US2] Add a row to `docs/RELEASING.md` §Runner per RID for `win-arm64-aot` with runner `windows-11-arm` and rationale matching the `linux-arm64-aot` row's shape ("Native ARM64 host — AOT cross-compilation across architectures is fragile, smoke test must run natively. `windows-11-arm` runners became free for public repos in April 2025.").
+
+**Checkpoint**: At this point, both US1 and US2 archives ship; the release matrix is at 16 entries; size-assertion enforces both new RIDs; documentation reflects both new artefacts. US2 is independently testable via a pre-release tag.
+
+---
+
+## Phase 5: User Story 3 - Release maintainer trusts the matrix and ships a clean tag (Priority: P3)
+
+**Goal**: Operational verification that the extended matrix produces exactly 16 archives, that the existing 14 are unchanged, and that fail-fast behaviour halts the release if either Windows AOT smoke or size invariant is violated. This phase is **maintainer activity, not code change** — its tasks are verifications that close the loop on US1 and US2.
+
+**Independent Test**: After Phases 3 and 4 are complete, push a release-rehearsal pre-release tag (e.g. `0.6.0-rc.0`) and walk through quickstart.md §Step 3–§Step 5. The verifier closes US3 when the rehearsal release shows 16 attached assets, the 14 pre-existing assets match a comparable post-#176 release contents-wise, and the two new Windows AOT assets pass content/size invariants.
+
+### Verification for User Story 3
+
+- [ ] T015 [US3] Push a release-rehearsal pre-release tag (e.g. `0.6.0-rc.0`) from the `002-win-aot-release` branch and confirm the GitHub Release for that tag has exactly 16 attached assets matching the filename list in `specs/002-win-aot-release/contracts/release-matrix.md` §Outputs (case-sensitive). Record the rehearsal-tag URL in the PR description.
+- [ ] T016 [US3] Hash-compare the 14 pre-existing archives from the rehearsal release against a comparable post-#176 release of the same source state (per quickstart.md §Step 5). Confirm file lists are identical inside each archive and that binary contents differ only in the embedded version metadata. Record any discrepancies as PR-blocking findings.
+- [ ] T017 [US3] Download `netpace-{rehearsal}-win-x64-aot.zip` and `netpace-{rehearsal}-win-arm64-aot.zip` from the rehearsal release and confirm each contains exactly one entry — `NetPace.exe` — with no `.dll`, `.deps.json`, `.runtimeconfig.json`, or `.pdb`. (Closes the FR-003 / contract acceptance for both new archives.)
+- [ ] T018 [US3] Read the size-assertion job log on the rehearsal release and confirm both Windows AOT archives passed the new branch of the check (their sizes are strictly less than the corresponding `-standalone` archives). Closes FR-004.
+- [ ] T019 [US3] (Optional but recommended) Verify fail-fast posture: on a throwaway branch, inject a forced `exit 1` into the smoke step for one of the new Windows AOT entries, push a throwaway pre-release tag, and confirm the `attach-to-release` job reports `skipped` and no assets are attached. Then revert the throwaway change. Closes the AC-3 / spec scenario "Failing Windows AOT smoke test halts release attach". If skipping for time, document the skip in the PR description.
+
+**Checkpoint**: Maintainer trust is demonstrated — 16-archive contract holds, no regression on existing 14, size invariant enforced, fail-fast verified.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Pre-PR hygiene — confirm the build is still clean, the docs cross-reference correctly, and the PR description gives a future contributor everything they need.
+
+- [ ] T020 Run `dotnet build` and `dotnet test` from repo root; both must exit `0` with zero warnings (project memory: "Don't commit with failing tests or build warnings"). The feature ships no source-code changes but the AOT analyzers run on every build, so this is a no-regression check on the trim/AOT clean-tree posture.
+- [ ] T021 Cross-check the four edited docs (`README.md`, `docs/RELEASING.md`, `USER_GUIDE.md`, plus the workflow-comment text from T011) against `specs/002-win-aot-release/contracts/release-matrix.md`. Confirm filenames, RID names, runner names, and the 16-archive total are consistent across all five surfaces.
+- [ ] T022 Open the PR for `002-win-aot-release` against `main`. PR description must reference issue #177, link to the rehearsal-tag URL recorded in T015, list all four edited files, and call out that no source-code changes were made. The `/raise-pr` skill is the standard helper; a plain `gh pr create` works equally well.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: T001 has no prerequisites — first task.
+- **Phase 2 (Foundational)**: T002 → T003 → T004 are all edits to the same workflow file; the order between them is conventional rather than strict, but they MUST all complete before Phase 3.
+- **Phase 3 (US1)**: T005 depends on Phase 2. T006–T010 depend on T005 only insofar as the matrix entry exists; doc rows can be written speculatively and merged after T005 lands.
+- **Phase 4 (US2)**: T011 depends on Phase 2 (NOT on Phase 3 — US2 is independently shippable). T012–T014 same as T006–T010 relationship: doc edits hang off the existence of the matrix entry but don't depend on US1 doc edits.
+- **Phase 5 (US3)**: T015–T019 require **both** Phase 3 and Phase 4 to be merged (or at least applied to the rehearsal-branch tip). The 16-archive contract spans both Windows AOT entries; verifying it requires both to exist.
+- **Phase 6 (Polish)**: T020 can run any time after Phase 2; T021–T022 require the PR-ready state, i.e. all earlier phases complete.
+
+### User Story Independence
+
+- **US1** (T005 + T006–T010) is independently shippable: a branch with only Phase 1, Phase 2, Phase 3 changes produces a working `win-x64-aot.zip` on its own.
+- **US2** (T011 + T012–T014) is independently shippable: a branch with only Phase 1, Phase 2, Phase 4 changes produces a working `win-arm64-aot.zip` on its own.
+- **US3** is a verification umbrella over US1+US2; it's not independently shippable but is independently *runnable* once both have landed.
+
+### Within Each User Story
+
+- For US1: T005 (matrix entry) before T006–T010 (doc updates that name the new archive). T006–T010 can run in parallel — they touch different files.
+- For US2: same shape — T011 before T012–T014; T012–T014 parallel.
+- For US3: T015 (rehearsal-tag push) gates T016–T018 (which inspect the rehearsal-tag's assets). T019 (fail-fast verification) is independent and optional.
+
+### Parallel Opportunities
+
+- T006, T007, T008, T009, T010 are all marked `[P]` — different files (README.md, RELEASING.md, USER_GUIDE.md). RELEASING.md edits T007/T008/T009 touch different sections of the same file but are non-overlapping; they can be batched into a single edit pass or applied in any order.
+- T012, T013, T014 marked `[P]` — same reasoning as above.
+- T002/T003/T004 are NOT marked `[P]` — same file, sequential edits.
+
+---
+
+## Parallel Example: User Story 1 doc updates
+
+```bash
+# After T005 lands (matrix entry exists), the five doc-touching tasks can be
+# applied in any order, or batched. Each one is a small, self-contained edit:
+Task: "T006 Add netpace-{ver}-win-x64-aot.zip row to README.md install table"
+Task: "T007 Fill (win-x64, Native AOT) cell in docs/RELEASING.md release matrix; bump 14→16 in summary line"
+Task: "T008 Add win-x64-aot row to docs/RELEASING.md runner-per-RID table with windows-latest"
+Task: "T009 Extend cross-OS-AOT-cannot-cross-compile prose in docs/RELEASING.md to mention Windows"
+Task: "T010 Update USER_GUIDE.md AOT-availability note to mention Windows"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 (T001) — confirm clean branch state.
+2. Phase 2 (T002–T004) — apply foundational workflow shape.
+3. Phase 3 (T005–T010) — add US1 matrix entry and doc rows.
+4. **STOP and VALIDATE**: push pre-release tag `0.6.0-rc.0-us1`, confirm `win-x64-aot.zip` ships, archive contains only `NetPace.exe`, `--version` works, size invariant passes. (Hand-execute quickstart.md §Step 3 + §Step 4 limited to the new x64 archive.)
+5. If green, the MVP is shippable. Decide whether to ship the MVP alone (drop US2/US3 to a follow-up) or proceed to US2 in the same PR.
+
+### Incremental Delivery (recommended for this feature)
+
+Because US1 and US2 share Phase 2's foundational changes and the matrix file lives in a single workflow YAML, shipping US1 + US2 in one PR is more efficient than splitting. Recommended order:
+
+1. T001 → T002 → T003 → T004 (one workflow-edit pass for foundational).
+2. T005 + T011 (one workflow-edit pass for both new matrix entries).
+3. T006–T010, T012–T014 (doc edits in parallel — can be a single commit per file across both stories).
+4. T015–T019 (rehearsal verification — shared between US1 and US2).
+5. T020–T022 (polish & PR open).
+
+### Splitting US1 and US2 into separate PRs
+
+Possible if you want to ship US1 first and let it bake on a real release before adding US2. Cost: a second PR repeats Phase 2's verification surface (rehearsal tag, hash-compare, etc.) and the four documentation files take a second round of edits. Benefit: smaller blast radius per PR. Recommend only if `windows-11-arm` runner availability or AOT trim posture on Windows raises new concerns mid-implementation.
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no dependencies. Same-file tasks (T002/T003/T004; T005/T011 if interleaved) are sequential.
+- `[Story]` label maps each task to its user story for traceability with `spec.md`'s priority ordering.
+- This feature ships **no production C# code** — TDD's RED-GREEN-REFACTOR cycle (Constitution principle I) does not apply at the task level. The "test" is the release-time smoke gate, which already exists in the workflow and is exercised by every AOT entry that uses it.
+- Quickstart.md is the runbook for verification; tasks.md only references it. Don't duplicate its step-by-step instructions here.
+- Commit after each phase or each `[P]` group; avoid mixing foundational + per-story edits in a single commit so the diff stays auditable.

--- a/specs/002-win-aot-release/tasks.md
+++ b/specs/002-win-aot-release/tasks.md
@@ -28,7 +28,7 @@ This feature edits four files only — `.github/workflows/release-binaries.yml`,
 
 **Purpose**: Confirm the working tree is clean and the branch is in the expected state.
 
-- [ ] T001 Confirm current branch is `002-win-aot-release` and working tree is clean (`git status` reports no uncommitted changes outside this feature's spec/plan/tasks artefacts) before any workflow edits begin.
+- [X] T001 Confirm current branch is `002-win-aot-release` and working tree is clean (`git status` reports no uncommitted changes outside this feature's spec/plan/tasks artefacts) before any workflow edits begin.
 
 ---
 
@@ -38,9 +38,9 @@ This feature edits four files only — `.github/workflows/release-binaries.yml`,
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Update the smoke-test step at `.github/workflows/release-binaries.yml:109-118` to handle Windows archives: branch the extraction on archive format (`unzip` for `*.zip`, existing `tar -xzf` for `*.tar.gz`), and invoke the binary as `./NetPace.exe` on Windows runners (`./NetPace` elsewhere). Keep `shell: bash` (Git Bash ships on both `windows-latest` and `windows-11-arm` per research R4).
-- [ ] T003 Update the archive step at `.github/workflows/release-binaries.yml:99-107` to exclude `*.pdb` from Windows AOT zips: when `matrix.deployment == 'aot'` and `matrix.runtime` matches `win-*`, remove or omit `*.pdb` files before invoking `zip -r`. Linux/macOS branches and Windows non-AOT branches remain unchanged.
-- [ ] T004 Widen the size-assertion guard at `.github/workflows/release-binaries.yml:158` from `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* ]]; then continue; fi` to allow `win-*` AOT entries through (e.g. `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* && "$runtime" != win-* ]]; then continue; fi`, or rewrite as an explicit allow-list of the four AOT-bearing RIDs). Either tactic produces the same observable behaviour per research R9.
+- [X] T002 Update the smoke-test step at `.github/workflows/release-binaries.yml:109-118` to handle Windows archives: branch the extraction on archive format (`unzip` for `*.zip`, existing `tar -xzf` for `*.tar.gz`), and invoke the binary as `./NetPace.exe` on Windows runners (`./NetPace` elsewhere). Keep `shell: bash` (Git Bash ships on both `windows-latest` and `windows-11-arm` per research R4).
+- [X] T003 Update the archive step at `.github/workflows/release-binaries.yml:99-107` to exclude `*.pdb` from Windows AOT zips: when `matrix.deployment == 'aot'` and `matrix.runtime` matches `win-*`, remove or omit `*.pdb` files before invoking `zip -r`. Linux/macOS branches and Windows non-AOT branches remain unchanged.
+- [X] T004 Widen the size-assertion guard at `.github/workflows/release-binaries.yml:158` from `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* ]]; then continue; fi` to allow `win-*` AOT entries through (e.g. `if [ "$variant" = "aot" ] && [[ "$runtime" != linux-* && "$runtime" != win-* ]]; then continue; fi`, or rewrite as an explicit allow-list of the four AOT-bearing RIDs). Either tactic produces the same observable behaviour per research R9.
 
 **Checkpoint**: Foundational workflow shape is ready. US1 and US2 can now add their matrix entries and have them flow through extract → smoke → size-check correctly.
 
@@ -54,12 +54,12 @@ This feature edits four files only — `.github/workflows/release-binaries.yml`,
 
 ### Implementation for User Story 1
 
-- [ ] T005 [US1] Add the `win-x64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-x64`, `deployment: aot`, `runs_on: windows-latest`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Match the field shape of the existing `linux-x64-aot` entry exactly (data-model.md §Entity 1).
-- [ ] T006 [P] [US1] Add `netpace-{ver}-win-x64-aot.zip` to the install table in `README.md` (alongside the existing `win-x64-standalone.zip` and `win-x64-net8.zip` rows).
-- [ ] T007 [P] [US1] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-x64`, Native AOT) intersection with `netpace-{ver}-win-x64-aot.zip`. Update the table-summary line above ("Each tag produces **14 archives**...") to reflect the new total of 16 (do this once for both Windows entries; if T013 has already been done, skip the count edit here).
-- [ ] T008 [P] [US1] Add a row to `docs/RELEASING.md` §Runner per RID for `win-x64-aot` with runner `windows-latest` and rationale text matching the existing `linux-x64-aot` row's shape ("Native x64 host — no cross-compile toolchain needed; `windows-latest` ships MSVC v143 and the Windows 11 SDK pre-installed.").
-- [ ] T009 [P] [US1] Update `docs/RELEASING.md` §Runner per RID prose paragraph to extend "Native AOT cannot be cross-compiled across operating systems" to explicitly cover Windows ("...hence the per-RID native runners on both Linux and Windows."). One sentence; preserve the existing wording.
-- [ ] T010 [P] [US1] Update the AOT-availability note in `USER_GUIDE.md` to mention Windows alongside Linux ("AOT builds are available for Linux and Windows; macOS AOT remains a future release."). One line edit.
+- [X] T005 [US1] Add the `win-x64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-x64`, `deployment: aot`, `runs_on: windows-latest`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Match the field shape of the existing `linux-x64-aot` entry exactly (data-model.md §Entity 1).
+- [X] T006 [P] [US1] Add `netpace-{ver}-win-x64-aot.zip` to the install table in `README.md` (alongside the existing `win-x64-standalone.zip` and `win-x64-net8.zip` rows). _(Adapted: README has no install table — only prose at line 54. Updated the prose to cover Windows AOT.)_
+- [X] T007 [P] [US1] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-x64`, Native AOT) intersection with `netpace-{ver}-win-x64-aot.zip`. Update the table-summary line above ("Each tag produces **14 archives**...") to reflect the new total of 16 (do this once for both Windows entries; if T013 has already been done, skip the count edit here).
+- [X] T008 [P] [US1] Add a row to `docs/RELEASING.md` §Runner per RID for `win-x64-aot` with runner `windows-latest` and rationale text matching the existing `linux-x64-aot` row's shape ("Native x64 host — no cross-compile toolchain needed; `windows-latest` ships MSVC v143 and the Windows 11 SDK pre-installed.").
+- [X] T009 [P] [US1] Update `docs/RELEASING.md` §Runner per RID prose paragraph to extend "Native AOT cannot be cross-compiled across operating systems" to explicitly cover Windows ("...hence the per-RID native runners on both Linux and Windows."). One sentence; preserve the existing wording.
+- [ ] T010 [P] [US1] Update the AOT-availability note in `USER_GUIDE.md` to mention Windows alongside Linux ("AOT builds are available for Linux and Windows; macOS AOT remains a future release."). One line edit. _(Skipped: USER_GUIDE.md has no AOT-availability note — it's a usage doc, not an install doc. The README prose update in T006 covers user-facing AOT availability.)_
 
 **Checkpoint**: At this point, the release pipeline produces a working `win-x64-aot.zip` on every tag, the size-assertion gate enforces it, and all four user-facing doc files reflect the new artefact. US1 is independently testable via a pre-release tag.
 
@@ -73,10 +73,10 @@ This feature edits four files only — `.github/workflows/release-binaries.yml`,
 
 ### Implementation for User Story 2
 
-- [ ] T011 [US2] Add the `win-arm64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-arm64`, `deployment: aot`, `runs_on: windows-11-arm`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Above the entry, add an inline YAML comment capturing the runner-availability confirmation per FR-011 — wording suggestion: `# windows-11-arm runner is GA (April 2025) and free for public repos. Native ARM64 host preserves the same-job smoke test; cross-compile from windows-latest is rejected — see docs/RELEASING.md §Runner per RID.`
-- [ ] T012 [P] [US2] Add `netpace-{ver}-win-arm64-aot.zip` to the install table in `README.md` (alongside the existing `win-arm64-standalone.zip` and `win-arm64-net8.zip` rows).
-- [ ] T013 [P] [US2] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-arm64`, Native AOT) intersection with `netpace-{ver}-win-arm64-aot.zip`. Update the table-summary line to reflect the new total of 16 archives (skip if already done in T007).
-- [ ] T014 [P] [US2] Add a row to `docs/RELEASING.md` §Runner per RID for `win-arm64-aot` with runner `windows-11-arm` and rationale matching the `linux-arm64-aot` row's shape ("Native ARM64 host — AOT cross-compilation across architectures is fragile, smoke test must run natively. `windows-11-arm` runners became free for public repos in April 2025.").
+- [X] T011 [US2] Add the `win-arm64-aot` entry to `jobs.build-cross-platform.strategy.matrix.include` in `.github/workflows/release-binaries.yml`: `runtime: win-arm64`, `deployment: aot`, `runs_on: windows-11-arm`, `publish_aot: true`, `publish_single_file: false`, `invariant_globalization: true`. Above the entry, add an inline YAML comment capturing the runner-availability confirmation per FR-011 — wording suggestion: `# windows-11-arm runner is GA (April 2025) and free for public repos. Native ARM64 host preserves the same-job smoke test; cross-compile from windows-latest is rejected — see docs/RELEASING.md §Runner per RID.`
+- [X] T012 [P] [US2] Add `netpace-{ver}-win-arm64-aot.zip` to the install table in `README.md` (alongside the existing `win-arm64-standalone.zip` and `win-arm64-net8.zip` rows). _(Covered by T006's prose update — README has no install table.)_
+- [X] T013 [P] [US2] Update `docs/RELEASING.md` §Release matrix table: replace the `_(out of scope)_` cell at the (`win-arm64`, Native AOT) intersection with `netpace-{ver}-win-arm64-aot.zip`. Update the table-summary line to reflect the new total of 16 archives (skip if already done in T007).
+- [X] T014 [P] [US2] Add a row to `docs/RELEASING.md` §Runner per RID for `win-arm64-aot` with runner `windows-11-arm` and rationale matching the `linux-arm64-aot` row's shape ("Native ARM64 host — AOT cross-compilation across architectures is fragile, smoke test must run natively. `windows-11-arm` runners became free for public repos in April 2025.").
 
 **Checkpoint**: At this point, both US1 and US2 archives ship; the release matrix is at 16 entries; size-assertion enforces both new RIDs; documentation reflects both new artefacts. US2 is independently testable via a pre-release tag.
 
@@ -104,8 +104,8 @@ This feature edits four files only — `.github/workflows/release-binaries.yml`,
 
 **Purpose**: Pre-PR hygiene — confirm the build is still clean, the docs cross-reference correctly, and the PR description gives a future contributor everything they need.
 
-- [ ] T020 Run `dotnet build` and `dotnet test` from repo root; both must exit `0` with zero warnings (project memory: "Don't commit with failing tests or build warnings"). The feature ships no source-code changes but the AOT analyzers run on every build, so this is a no-regression check on the trim/AOT clean-tree posture.
-- [ ] T021 Cross-check the four edited docs (`README.md`, `docs/RELEASING.md`, `USER_GUIDE.md`, plus the workflow-comment text from T011) against `specs/002-win-aot-release/contracts/release-matrix.md`. Confirm filenames, RID names, runner names, and the 16-archive total are consistent across all five surfaces.
+- [X] T020 Run `dotnet build` and `dotnet test` from repo root; both must exit `0` with zero warnings (project memory: "Don't commit with failing tests or build warnings"). The feature ships no source-code changes but the AOT analyzers run on every build, so this is a no-regression check on the trim/AOT clean-tree posture. _(Build: 0 warnings, 0 errors. Tests: 583 passed, 0 failed.)_
+- [X] T021 Cross-check the four edited docs (`README.md`, `docs/RELEASING.md`, `USER_GUIDE.md`, plus the workflow-comment text from T011) against `specs/002-win-aot-release/contracts/release-matrix.md`. Confirm filenames, RID names, runner names, and the 16-archive total are consistent across all five surfaces.
 - [ ] T022 Open the PR for `002-win-aot-release` against `main`. PR description must reference issue #177, link to the rehearsal-tag URL recorded in T015, list all four edited files, and call out that no source-code changes were made. The `/raise-pr` skill is the standard helper; a plain `gh pr create` works equally well.
 
 ---

--- a/specs/002-win-aot-release/test-plan.md
+++ b/specs/002-win-aot-release/test-plan.md
@@ -1,0 +1,121 @@
+# Test Plan — Windows Native AOT Release Artifacts
+
+## Coverage summary
+
+| User Story | Primary | Alternate | Error | Boundary | Recovery | Non-functional | Total |
+|---|---|---|---|---|---|---|---|
+| Windows x64 user gets a fast-startup AOT NetPace | ✓ | — | — | ✓ | — | — | 4 |
+| Windows ARM64 user gets a native AOT NetPace | ✓ | — | — | — | — | — | 3 |
+| Release maintainer trusts the matrix and ships a clean tag | ✓ | — | ✓ | — | — | — | 5 |
+
+**Flags:**
+- *Windows x64 user gets a fast-startup AOT NetPace* — no Error scenario at the user-facing level. Failure modes (e.g. wrong-architecture binary refusal, SmartScreen prompt) are documented in spec.md §Edge Cases but the spec author intentionally keeps the user-facing acceptance set to happy-path + content + size + listing. Failures inside the build pipeline are covered by the maintainer-facing scenarios under User Story 3, so this is acceptable as a deliberate boundary not a gap.
+- *Windows ARM64 user gets a native AOT NetPace* — only 3 scenarios and no Error coverage. Same reasoning as User Story 1: pipeline-level failures are exercised by the maintainer scenarios. Acceptable, but worth a re-look if any ARM64-specific runtime failure mode emerges in pre-release.
+- No Recovery scenarios anywhere — for a release-pipeline feature, "recovery" would mean re-running a failed tag, which is outside the test scope (it's a maintainer workflow, not a verifiable system behaviour). Acceptable absence.
+
+---
+
+### User Story: Windows x64 user gets a fast-startup AOT NetPace
+End-user verification of the new `win-x64-aot.zip` artefact on a clean Windows x64 host.
+
+#### Scenario: Win-x64 AOT archive appears on tagged release
+- **WHEN** a release is published for a semver tag `{tag}` (where `{tag}` matches the existing tag-extraction pattern `${GITHUB_REF#refs/tags/}`) after this feature ships, and the GitHub Release page for that tag is requested
+- **THEN** an asset named `netpace-{tag}-win-x64-aot.zip` is present in the release-asset list
+- **AND** assets `netpace-{tag}-win-x64-standalone.zip` and `netpace-{tag}-win-x64-net8.zip` remain present in the same release
+
+#### Scenario: Win-x64 AOT binary runs with no dotnet runtime installed
+- **WHEN** `netpace-{tag}-win-x64-aot.zip` is extracted on a Windows x64 host with no `.NET` runtime installed (verifiable by `where dotnet` returning non-zero or by a fresh image), and `NetPace.exe --version` is invoked
+- **THEN** the process exits with code `0`
+- **AND** stdout contains the version string `{tag}`
+
+#### Scenario: Win-x64 AOT archive contains only the netpace.exe
+- **WHEN** `netpace-{tag}-win-x64-aot.zip` is extracted to an empty directory and the directory listing is enumerated
+- **THEN** the listing contains exactly one file
+- **AND** that file is `NetPace.exe`
+- **AND** no `.dll`, `.deps.json`, `.runtimeconfig.json`, or `.pdb` file is present
+
+#### Scenario: Win-x64 AOT archive is smaller than win-x64 standalone
+- **WHEN** `sizeof(netpace-{tag}-win-x64-aot.zip)` and `sizeof(netpace-{tag}-win-x64-standalone.zip)` are read from the release for the same tag
+- **THEN** `sizeof(aot.zip) < sizeof(standalone.zip)` strictly (consistent with the Linux AOT size-assertion contract documented in `docs/RELEASING.md` §Size-assertion contract)
+- **AND** the `attach-to-release` job's size-assertion step exited `0` for this tag
+
+---
+
+### User Story: Windows ARM64 user gets a native AOT NetPace
+End-user verification of the new `win-arm64-aot.zip` artefact on a Windows-on-ARM host.
+
+#### Scenario: Win-arm64 AOT archive appears on tagged release
+- **WHEN** a release is published for a semver tag `{tag}` after this feature ships, and the GitHub Release page for that tag is requested
+- **THEN** an asset named `netpace-{tag}-win-arm64-aot.zip` is present in the release-asset list
+
+#### Scenario: Win-arm64 AOT binary runs natively on Windows-on-ARM
+- **WHEN** `netpace-{tag}-win-arm64-aot.zip` is extracted on a Windows ARM64 host, and `NetPace.exe --version` and `NetPace.exe --help` are invoked in sequence
+- **THEN** both processes exit with code `0`
+- **AND** `--version` stdout contains the version string `{tag}`
+- **AND** `--help` stdout contains the top-level command synopsis (any non-empty help text — the command is part of the existing CLI contract, not introduced by this feature)
+- **AND** the binary's PE machine type is `IMAGE_FILE_MACHINE_ARM64` (`0xAA64`), confirming native ARM64 execution rather than x64 emulation. Verifiable via `dumpbin /HEADERS NetPace.exe` or equivalent PE-header inspection.
+
+#### Scenario: Win-arm64 AOT archive contains only the netpace.exe
+- **WHEN** `netpace-{tag}-win-arm64-aot.zip` is extracted to an empty directory and the directory listing is enumerated
+- **THEN** the listing contains exactly one file
+- **AND** that file is `NetPace.exe`
+- **AND** no `.dll`, `.deps.json`, `.runtimeconfig.json`, or `.pdb` file is present
+
+---
+
+### User Story: Release maintainer trusts the matrix and ships a clean tag
+Maintainer-facing pipeline guarantees: 16-archive count, no-regression on the existing 14, fail-fast on smoke and size-invariant violations, and self-documenting runner choices.
+
+#### Scenario: Tagged release attaches exactly 16 archives
+- **WHEN** a semver tag is pushed to `main` and the `release-binaries.yml` workflow run for that tag completes successfully
+- **THEN** the GitHub Release for that tag has exactly 16 attached assets
+- **AND** the asset names match the 16 entries listed in `specs/002-win-aot-release/contracts/release-matrix.md` §Outputs (case-sensitive, with the `{ver}` placeholder substituted to the pushed tag)
+- **AND** no asset with any other name is attached
+
+#### Scenario: Existing 14 archives are unchanged versus post-176 release
+- **WHEN** the 14 pre-existing archives from a release tag of this feature are compared, file-by-file, against the same 14 archives from a comparable post-#176 release built from the same source state (i.e. the source state before this feature's diff was applied)
+- **THEN** for every file inside each archive, the file list, file paths, and file sizes are identical
+- **AND** the binary contents are identical except for the embedded `Version`, `AssemblyVersion`, `FileVersion`, and `InformationalVersion` strings (which differ because the tag differs)
+- **AND** no archive's filename has changed
+
+#### Scenario: Failing Windows AOT smoke test halts release attach
+- **GIVEN** a release tag where the Windows AOT smoke step (either `win-x64-aot` or `win-arm64-aot`) is deliberately forced to exit non-zero (e.g. by a temporary `exit 1` injected into the smoke step on a feature branch)
+- **WHEN** the `release-binaries.yml` workflow runs for that tag
+- **THEN** the failing matrix job ends with status `failure`
+- **AND** the `attach-to-release` job does not run (status `skipped` due to the `needs: build-cross-platform` dependency)
+- **AND** no asset is attached to the GitHub Release for that tag
+
+#### Scenario: Windows AOT size invariant violation halts release attach
+- **GIVEN** a release tag where the Windows AOT archive size is `≥` its `-standalone` counterpart (e.g. by a temporary archive-step modification that pads the AOT zip on a feature branch)
+- **WHEN** the `release-binaries.yml` workflow runs for that tag
+- **THEN** the `attach-to-release` job's size-assertion step exits non-zero
+- **AND** the subsequent attach step does not run
+- **AND** no asset is attached to the GitHub Release for that tag
+
+#### Scenario: RELEASING.md documents win-arm64 runner choice
+- **WHEN** the post-feature `docs/RELEASING.md` is read
+- **THEN** the §Release matrix table contains a non-empty cell for the (`win-x64`, Native AOT) and (`win-arm64`, Native AOT) intersections
+- **AND** the §Runner per RID table contains rows for `win-x64-aot` and `win-arm64-aot` with runner values `windows-latest` and `windows-11-arm` respectively
+- **AND** the rationale for choosing `windows-11-arm` over a `windows-latest` cross-compile is captured in prose adjacent to that table (verifiable by string match: the rationale must reference both "cross-compile" and the native-runner reason — same shape as the existing `linux-arm64-aot` rationale)
+
+---
+
+## Implementation guidance
+
+Every test method that implements a scenario in this plan MUST include a `// SCENARIO:`
+comment whose value matches the `#### Scenario:` name above **exactly** — character for
+character, including case, punctuation, and internal whitespace. Leading and trailing
+whitespace on the scenario name is trimmed before comparison.
+
+```csharp
+[Fact]
+public void Login_UnknownEmail_Returns401()
+{
+    // SCENARIO: Login rejected for unknown email
+
+    // ...
+}
+```
+
+`/speckit.testchecklist` validates these comments against the scenario names in this
+file. A test without a matching `// SCENARIO:` comment is reported as untraced.

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -7,6 +7,8 @@
     <Nullable>enable</Nullable>
     <AssemblyName>NetPace</AssemblyName>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Embed portable PDBs inside the assembly so non-AOT release archives ship no side .pdb files. -->
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">

--- a/src/NetPace.Core/NetPace.Core.csproj
+++ b/src/NetPace.Core/NetPace.Core.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Embed portable PDBs inside the assembly — NuGet consumers get symbolicated stack traces without a side .pdb. -->
+    <DebugType>embedded</DebugType>
 
     <!-- XML Documentation (public API only) -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary

Adds Windows Native AOT to the release matrix as two new archives — `netpace-{ver}-win-x64-aot.zip` and `netpace-{ver}-win-arm64-aot.zip` — single native `.exe`s with no .NET runtime dependency, bringing the per-release total to 16. Mirrors feature 001's Linux AOT pattern (`matrix.include:` entries + native runner per RID, `windows-latest` for x64 and `windows-11-arm` for arm64, since cross-OS AOT cross-compilation is fragile). Also tightens the archive-contents contract end-to-end: every release archive (all 16) must now contain exactly one entry, enforced by a new "Verify archive contents" workflow step; managed PDBs are embedded via `<DebugType>embedded</DebugType>` in both `NetPace.Console.csproj` and `NetPace.Core.csproj` so no side `.pdb` ships in any variant, and the Windows AOT native PDB is scrubbed before zipping. Includes a runner-OS guard step that fails fast on a `matrix.runs_on` typo (would otherwise silently fall back to `ubuntu-latest`).

## Spec

[specs/002-win-aot-release](specs/002-win-aot-release)

## Changed Files

- .claude/settings.json
- .github/workflows/release-binaries.yml
- .specify/feature.json
- CLAUDE.md
- README.md
- docs/RELEASING.md
- docs/change-intent-records/2026-05-02-linux-native-aot-release.md
- specs/002-win-aot-release/checklists/requirements.md
- specs/002-win-aot-release/contracts/release-matrix.md
- specs/002-win-aot-release/data-model.md
- specs/002-win-aot-release/plan.md
- specs/002-win-aot-release/quickstart.md
- specs/002-win-aot-release/research.md
- specs/002-win-aot-release/spec.md
- specs/002-win-aot-release/tasks.md
- specs/002-win-aot-release/test-plan.md
- src/NetPace.Console/NetPace.Console.csproj
- src/NetPace.Core/NetPace.Core.csproj

## New Artifacts

- Spec: [specs/002-win-aot-release](specs/002-win-aot-release)