### PR TITLE
Skip NuGet publish when NetPace.Core unchanged since previous tag

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -21,11 +21,12 @@ jobs:
         id: core_changed
         run: |
           set -euo pipefail
-          PREV_TAG=$(git describe --tags --abbrev=0 "${GITHUB_REF}^" 2>/dev/null || echo "")
+          TAG_COMMIT=$(git rev-parse "${GITHUB_REF}^0")
+          PREV_TAG=$(git describe --tags --abbrev=0 "${TAG_COMMIT}^" 2>/dev/null || echo "")
           if [ -z "$PREV_TAG" ]; then
             echo "No previous tag found — treating as first release, will publish."
             echo "changed=true" >> $GITHUB_OUTPUT
-          elif git diff --quiet "$PREV_TAG"..."${GITHUB_REF}" -- src/NetPace.Core; then
+          elif git diff --quiet "$PREV_TAG".."${GITHUB_REF}" -- src/NetPace.Core; then
             echo "NetPace.Core unchanged since $PREV_TAG — skipping NuGet pack/push."
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -13,7 +13,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Fetch tags for diff
+        run: git fetch --tags --force --unshallow || git fetch --tags --force
+
+      - name: Check if NetPace.Core changed since previous tag
+        id: core_changed
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git describe --tags --abbrev=0 "${GITHUB_REF}^" 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found — treating as first release, will publish."
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git diff --quiet "$PREV_TAG"..."${GITHUB_REF}" -- src/NetPace.Core; then
+            echo "NetPace.Core unchanged since $PREV_TAG — skipping NuGet pack/push."
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "NetPace.Core changed since $PREV_TAG — will publish."
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup .NET
+        if: steps.core_changed.outputs.changed == 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
@@ -23,12 +43,15 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
+        if: steps.core_changed.outputs.changed == 'true'
         run: dotnet restore src
 
       - name: Build
+        if: steps.core_changed.outputs.changed == 'true'
         run: dotnet build src --configuration Release --no-restore
 
       - name: Pack
+        if: steps.core_changed.outputs.changed == 'true'
         run: |
           dotnet pack src/NetPace.Core/NetPace.Core.csproj \
             --configuration Release \
@@ -42,6 +65,7 @@ jobs:
             -o ./output
 
       - name: Publish to NuGet
+        if: steps.core_changed.outputs.changed == 'true'
         run: |
           dotnet nuget push ./output/*.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -6,15 +6,16 @@ on:
       - '*'  # Match any tag like 0.4.0, 1.0.0, etc.
 
 jobs:
-  build-and-publish:
+  check:
     runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.core_changed.outputs.changed }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Fetch tags for diff
-        run: git fetch --tags --force --unshallow || git fetch --tags --force
+        with:
+          fetch-depth: 0  # Need full history + tags for diff against previous tag
 
       - name: Check if NetPace.Core changed since previous tag
         id: core_changed
@@ -32,8 +33,16 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
+  publish:
+    needs: check
+    if: needs.check.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup .NET
-        if: steps.core_changed.outputs.changed == 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
@@ -43,15 +52,12 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        if: steps.core_changed.outputs.changed == 'true'
         run: dotnet restore src
 
       - name: Build
-        if: steps.core_changed.outputs.changed == 'true'
         run: dotnet build src --configuration Release --no-restore
 
       - name: Pack
-        if: steps.core_changed.outputs.changed == 'true'
         run: |
           dotnet pack src/NetPace.Core/NetPace.Core.csproj \
             --configuration Release \
@@ -65,7 +71,6 @@ jobs:
             -o ./output
 
       - name: Publish to NuGet
-        if: steps.core_changed.outputs.changed == 'true'
         run: |
           dotnet nuget push ./output/*.nupkg \
             --api-key ${{ secrets.NUGET_API_KEY }} \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -77,6 +77,16 @@ Either invariant failing fails the entire release job; no archives are attached.
 
 The `IsAotCompatible=true` property on `NetPace.Core.csproj` causes `dotnet pack` to emit `[assembly: AssemblyMetadata("IsTrimmable", "True")]` into the packaged DLL — the standard .NET 8 marker NuGet uses to surface AOT compatibility to consumers. The `publish-nuget.yml` workflow is unchanged by this feature and continues to consume the property transparently.
 
+## Conditional NuGet publish
+
+`publish-nuget.yml` only packs and pushes `NetPace.Core` when `src/NetPace.Core/**` has changed between the current tag and the previous tag. On CLI-only tags (the common case — ~90% of releases), the workflow logs a skip message and exits successfully without invoking `dotnet pack` or `nuget push`.
+
+**Why**: each tag would otherwise produce a new `NetPace.Core` version on nuget.org byte-equivalent to the previous one, eroding SemVer meaning for library consumers.
+
+**Consequence**: `NetPace.Core` versions published to nuget.org may skip values (e.g. `0.5.0` → `0.7.0`) when intermediate tags were CLI-only. This is intentional — the published version always reflects a real Core change.
+
+The GitHub Release / binary-attachment flow via `release-binaries.yml` is unaffected and ships every tag.
+
 ## Release notes
 
 Per-release "what changed" notes are **GitHub-auto-generated from the PRs merged since the last tag** — there is no `CHANGELOG.md` to maintain. The `NetPace.Core.csproj` `<PackageReleaseNotes>` property already points NuGet consumers to <https://github.com/FrankRay78/NetPace/releases>, so the auto-generated notes are the single source of truth for both CLI and library audiences. Edit the GitHub Release body manually only when a particular change deserves prose framing the auto-generated PR list can't supply.


### PR DESCRIPTION
## Summary

Closes #186. Both `publish-nuget.yml` and `release-binaries.yml` trigger on every tag, so byte-equivalent `NetPace.Core` packages were being pushed to nuget.org on every CLI-only release (~90% of tags), eroding SemVer meaning for library consumers. This PR adds a tag-diff guard step to `publish-nuget.yml` that compares `src/NetPace.Core/**` between the current and previous tag and gates the Setup .NET / Restore / Build / Pack / Publish steps on the result. First-ever-tag returns `changed=true` (safe default); `release-binaries.yml` is untouched.

## Spec

N/A

## Changed Files

- .github/workflows/publish-nuget.yml
- docs/RELEASING.md