### PR TITLE
Remove InternalsVisibleTo from NetPace.Core

### DIFF
--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.ServerListParsing.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.ServerListParsing.cs
@@ -10,8 +10,7 @@ public sealed partial class OoklaSpeedtestTests
     [Fact]
     public async Task GetServersAsync_RepresentativeOoklaResponse_ReturnsAllRequiredAttributes()
     {
-        // SCENARIO: Parser deserializes a representative Ookla server-list response
-
+        // Given
         const string Xml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <settings>
@@ -25,10 +24,14 @@ public sealed partial class OoklaSpeedtestTests
             </settings>
             """;
 
-        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*").Respond("application/xml", Xml);
+        var speedtest = new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
 
+        // When
         var servers = await speedtest.GetServersAsync();
 
+        // Then
         servers.Length.ShouldBe(5);
 
         var first = servers[0].ShouldBeOfType<OoklaServer>();
@@ -43,8 +46,7 @@ public sealed partial class OoklaSpeedtestTests
     [Fact]
     public async Task GetServersAsync_OptionalAttributesPresent_PopulatesCountryAndHost()
     {
-        // SCENARIO: Parser populates optional attributes when present
-
+        // Given
         const string Xml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <settings>
@@ -54,10 +56,14 @@ public sealed partial class OoklaSpeedtestTests
             </settings>
             """;
 
-        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*").Respond("application/xml", Xml);
+        var speedtest = new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
 
+        // When
         var servers = await speedtest.GetServersAsync();
 
+        // Then
         var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
         server.Country.ShouldBe("United Kingdom");
         server.Host.ShouldBe("host.example.com:8080");
@@ -66,8 +72,7 @@ public sealed partial class OoklaSpeedtestTests
     [Fact]
     public async Task GetServersAsync_OptionalAttributesAbsent_LeavesCountryAndHostNull()
     {
-        // SCENARIO: Parser leaves optional attributes null when absent
-
+        // Given
         const string Xml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <settings>
@@ -77,10 +82,14 @@ public sealed partial class OoklaSpeedtestTests
             </settings>
             """;
 
-        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*").Respond("application/xml", Xml);
+        var speedtest = new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
 
+        // When
         var servers = await speedtest.GetServersAsync();
 
+        // Then
         var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
         server.Country.ShouldBeNull();
         server.Host.ShouldBeNull();
@@ -89,8 +98,6 @@ public sealed partial class OoklaSpeedtestTests
     [Fact]
     public async Task GetServersAsync_NumericAttributes_UsesInvariantCultureUnderCommaDecimalLocale()
     {
-        // SCENARIO: Parser uses invariant culture for numeric attribute parsing
-
         const string Xml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <settings>
@@ -103,12 +110,17 @@ public sealed partial class OoklaSpeedtestTests
         var originalCulture = CultureInfo.CurrentCulture;
         try
         {
+            // Given
             CultureInfo.CurrentCulture = new CultureInfo("de-DE");
 
-            var speedtest = BuildSpeedtestWithXmlResponse(Xml);
+            using var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When("*").Respond("application/xml", Xml);
+            var speedtest = new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
 
+            // When
             var servers = await speedtest.GetServersAsync();
 
+            // Then
             var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
             server.Latitude.ShouldBe(51.5074);
             server.Longitude.ShouldBe(-0.1278);
@@ -122,8 +134,7 @@ public sealed partial class OoklaSpeedtestTests
     [Fact]
     public async Task GetServersAsync_EmptyServersElement_ReturnsEmptyCollection()
     {
-        // SCENARIO: Parser handles an empty servers element
-
+        // Given
         const string Xml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <settings>
@@ -131,17 +142,14 @@ public sealed partial class OoklaSpeedtestTests
             </settings>
             """;
 
-        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*").Respond("application/xml", Xml);
+        var speedtest = new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
 
+        // When
         var servers = await speedtest.GetServersAsync();
 
+        // Then
         servers.ShouldBeEmpty();
-    }
-
-    private static OoklaSpeedtest BuildSpeedtestWithXmlResponse(string xml)
-    {
-        var mockHttp = new MockHttpMessageHandler();
-        mockHttp.When("*").Respond("application/xml", xml);
-        return new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
     }
 }

--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.ServerListParsing.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.ServerListParsing.cs
@@ -1,15 +1,14 @@
 using System.Globalization;
-using System.Xml;
 using NetPace.Core.Clients.Ookla;
-using NetPace.Core.Clients.Ookla.Extensions;
+using RichardSzalay.MockHttp;
 using Shouldly;
 
-namespace NetPace.Core.Tests.Clients.Ookla.Extensions;
+namespace NetPace.Core.Tests;
 
-public class XmlExtensionsTests
+public sealed partial class OoklaSpeedtestTests
 {
     [Fact]
-    public void Deserialize_RepresentativeOoklaResponse_PopulatesAllRequiredAttributes()
+    public async Task GetServersAsync_RepresentativeOoklaResponse_ReturnsAllRequiredAttributes()
     {
         // SCENARIO: Parser deserializes a representative Ookla server-list response
 
@@ -26,13 +25,13 @@ public class XmlExtensionsTests
             </settings>
             """;
 
-        var result = Xml.DeserializeFromXml();
+        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
 
-        result.ShouldNotBeNull();
-        result.Servers.ShouldNotBeNull();
-        result.Servers.Length.ShouldBe(5);
+        var servers = await speedtest.GetServersAsync();
 
-        var first = result.Servers[0];
+        servers.Length.ShouldBe(5);
+
+        var first = servers[0].ShouldBeOfType<OoklaServer>();
         first.Id.ShouldBe(1234);
         first.Location.ShouldBe("London");
         first.Sponsor.ShouldBe("Acme ISP");
@@ -42,7 +41,7 @@ public class XmlExtensionsTests
     }
 
     [Fact]
-    public void Deserialize_OptionalAttributesPresent_PopulatesCountryAndHost()
+    public async Task GetServersAsync_OptionalAttributesPresent_PopulatesCountryAndHost()
     {
         // SCENARIO: Parser populates optional attributes when present
 
@@ -55,15 +54,17 @@ public class XmlExtensionsTests
             </settings>
             """;
 
-        var result = Xml.DeserializeFromXml();
+        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
 
-        var server = result!.Servers!.Single();
+        var servers = await speedtest.GetServersAsync();
+
+        var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
         server.Country.ShouldBe("United Kingdom");
         server.Host.ShouldBe("host.example.com:8080");
     }
 
     [Fact]
-    public void Deserialize_OptionalAttributesAbsent_LeavesCountryAndHostNull()
+    public async Task GetServersAsync_OptionalAttributesAbsent_LeavesCountryAndHostNull()
     {
         // SCENARIO: Parser leaves optional attributes null when absent
 
@@ -76,15 +77,17 @@ public class XmlExtensionsTests
             </settings>
             """;
 
-        var result = Xml.DeserializeFromXml();
+        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
 
-        var server = result!.Servers!.Single();
+        var servers = await speedtest.GetServersAsync();
+
+        var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
         server.Country.ShouldBeNull();
         server.Host.ShouldBeNull();
     }
 
     [Fact]
-    public void Deserialize_NumericAttributes_UsesInvariantCultureUnderCommaDecimalLocale()
+    public async Task GetServersAsync_NumericAttributes_UsesInvariantCultureUnderCommaDecimalLocale()
     {
         // SCENARIO: Parser uses invariant culture for numeric attribute parsing
 
@@ -102,9 +105,11 @@ public class XmlExtensionsTests
         {
             CultureInfo.CurrentCulture = new CultureInfo("de-DE");
 
-            var result = Xml.DeserializeFromXml();
+            var speedtest = BuildSpeedtestWithXmlResponse(Xml);
 
-            var server = result!.Servers!.Single();
+            var servers = await speedtest.GetServersAsync();
+
+            var server = servers.ShouldHaveSingleItem().ShouldBeOfType<OoklaServer>();
             server.Latitude.ShouldBe(51.5074);
             server.Longitude.ShouldBe(-0.1278);
         }
@@ -115,7 +120,7 @@ public class XmlExtensionsTests
     }
 
     [Fact]
-    public void Deserialize_EmptyServersElement_ReturnsEmptyOrNullCollection()
+    public async Task GetServersAsync_EmptyServersElement_ReturnsEmptyCollection()
     {
         // SCENARIO: Parser handles an empty servers element
 
@@ -126,24 +131,17 @@ public class XmlExtensionsTests
             </settings>
             """;
 
-        var result = Xml.DeserializeFromXml();
+        var speedtest = BuildSpeedtestWithXmlResponse(Xml);
 
-        result.ShouldNotBeNull();
-        (result.Servers is null || result.Servers.Length == 0).ShouldBeTrue();
+        var servers = await speedtest.GetServersAsync();
+
+        servers.ShouldBeEmpty();
     }
 
-    [Fact]
-    public void Deserialize_MalformedXml_ThrowsXmlException()
+    private static OoklaSpeedtest BuildSpeedtestWithXmlResponse(string xml)
     {
-        // SCENARIO: Parser throws on malformed XML
-
-        const string Xml = "<settings><servers><server id=\"1\" /></servers"; // unclosed
-
-        var thrown = Should.Throw<Exception>(() => Xml.DeserializeFromXml());
-
-        // Accept either an XmlException directly or an InvalidOperationException wrapping one
-        var isXmlOrWrapped = thrown is XmlException
-            || (thrown is InvalidOperationException && thrown.InnerException is XmlException);
-        isXmlOrWrapped.ShouldBeTrue($"Expected XmlException or InvalidOperationException(XmlException), got {thrown.GetType()}");
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*").Respond("application/xml", xml);
+        return new OoklaSpeedtest(httpClientOverride: mockHttp.ToHttpClient());
     }
 }

--- a/src/NetPace.Core/NetPace.Core.csproj
+++ b/src/NetPace.Core/NetPace.Core.csproj
@@ -42,5 +42,4 @@
     <None Include="$(MSBuildThisFileDirectory)..\..\resources\nuget\logo.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
-
 </Project>

--- a/src/NetPace.Core/NetPace.Core.csproj
+++ b/src/NetPace.Core/NetPace.Core.csproj
@@ -42,7 +42,5 @@
     <None Include="$(MSBuildThisFileDirectory)..\..\resources\nuget\logo.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="NetPace.Core.Tests" />
-  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Removes `<InternalsVisibleTo Include="NetPace.Core.Tests" />` from `NetPace.Core.csproj` so the published NuGet library no longer leaks internals to its test assembly. The 6 `XmlExtensions` parser-correctness scenarios are re-routed through the public `OoklaSpeedtest.GetServersAsync()` surface using `MockHttpMessageHandler` — matching the consumer-equivalent pattern already used elsewhere in `OoklaSpeedtestTests.cs`. 5 scenarios are ported to a new `OoklaSpeedtestTests.ServerListParsing.cs` partial class; the malformed-XML scenario was already covered by `GetServersAsync_ShouldThrow_WhenResponseIsInvalid`, so it is deduplicated.

Closes #184

## Spec

N/A

## Changed Files

- `src/NetPace.Core.Tests/Clients/Ookla/Extensions/XmlExtensionsTests.cs` → `src/NetPace.Core.Tests/OoklaSpeedtestTests.ServerListParsing.cs` (renamed, tests re-routed via public API)
- `src/NetPace.Core/NetPace.Core.csproj` (InternalsVisibleTo declaration removed)