### PR TITLE
Fix release archives: exclude NetPace.Core.xml from publish output

### DIFF
--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -9,6 +9,9 @@
     <IsAotCompatible>true</IsAotCompatible>
     <!-- Embed portable PDBs inside the assembly so non-AOT release archives ship no side .pdb files. -->
     <DebugType>embedded</DebugType>
+    <!-- Prevent NetPace.Core.xml from landing in publish output — PublishSingleFile bundles the DLL but not XML,
+         so without this the documentation file appears as a stray second entry in every release archive. -->
+    <AllowedReferenceRelatedFileExtensions>.pdb</AllowedReferenceRelatedFileExtensions>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">


### PR DESCRIPTION
Fix for the failed `release-binaries` workflow on tag 0.23.0.

Adds `AllowedReferenceRelatedFileExtensions=.pdb` to `NetPace.Console.csproj` to prevent `NetPace.Core.xml` from being copied to the publish output. Without this, `PublishSingleFile` bundles the DLL but not the XML, causing every release archive to contain a stray second entry that fails the "Verify archive contents" check.

Related to PR #193.

Generated with [Claude Code](https://claude.ai/code)) · [Branch](https://github.com/FrankRay78/NetPace/tree/claude/pr-193-20260513-0831