### PR TITLE
Fix release archives: remove NetPace.Core.xml from publish output

### DIFF
--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -31,4 +31,13 @@
 	<InternalsVisibleTo Include="NetPace.Console.Tests" />
   </ItemGroup>
 
+  <!-- Remove XML documentation files from publish output: PublishSingleFile bundles DLLs but not XML files,
+       so NetPace.Core.xml would land loose in every archive and break the "exactly 1 entry" contract. -->
+  <Target Name="ExcludeDocXmlFromPublish" AfterTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+        Condition="'%(Extension)' == '.xml'" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Fixes the failed `release-binaries` workflow on tags 0.23.0 and 0.23.1.

## Root Cause

`NetPace.Core.csproj` has `GenerateDocumentationFile=true` (needed for NuGet IntelliSense). When `NetPace.Console` publishes, MSBuild copies `NetPace.Core.xml` into the publish directory. `PublishSingleFile=true` bundles DLLs but explicitly excludes XML files, so the XML lands loose and breaks the "exactly 1 entry" archive contract across all non-AOT variants.

The previous attempt (`AllowedReferenceRelatedFileExtensions`) was never merged and was also the wrong fix: it filters at the `ResolveAssemblyReferences` (build) stage, not the `ComputeFilesToPublish` (publish) stage.

## Fix

Adds an MSBuild `AfterTargets="ComputeFilesToPublish"` target in `NetPace.Console.csproj` that removes `.xml` entries from `ResolvedFileToPublish`. This covers all 16 matrix variants (PublishSingleFile and AOT). `dotnet pack` for `NetPace.Core` is unaffected — packing uses `_PackageFiles`, not `ResolvedFileToPublish`.

Related to PR #193.

Generated with [Claude Code](https://claude.ai/code)