### PR TITLE
Archive release binary by name instead of scrubbing sidecars

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -131,20 +131,22 @@ jobs:
             -p:FileVersion=${{ steps.get_version.outputs.version }} \
             -p:InformationalVersion=${{ steps.get_version.outputs.version }}
 
-      # shell: bash forces Git Bash on the Windows runners so the same script (zip vs tar, glob branching) runs uniformly across all matrix entries.
+      # shell: bash forces Git Bash on the Windows runners so the same script (zip vs tar) runs uniformly across all matrix entries.
+      # Whitelist approach: archive the executable by name rather than the entire publish directory. All variants
+      # (PublishSingleFile and Native AOT) produce a single binary by design; the publish dir may also contain
+      # toolchain by-products (NetPace.Core.xml, NetPace.pdb on Windows AOT, NetPace.dbg on Linux AOT) that
+      # must never ship to end users. Archiving by name keeps the release contract immune to whatever the
+      # next toolchain version decides to emit alongside the binary.
       - name: Create archive
         shell: bash
         run: |
           set -euo pipefail
           cd ./publish/${{ matrix.runtime }}-${{ matrix.deployment }}
+          archive_stem="../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}"
           if [[ "${{ matrix.runtime }}" == win-* ]]; then
-            if [ "${{ matrix.deployment }}" = "aot" ]; then
-              # Strip debug symbols from Windows AOT archives — release contract: archive contains only NetPace.exe.
-              rm -f ./*.pdb
-            fi
-            zip -r ../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}.zip .
+            zip "${archive_stem}.zip" NetPace.exe
           else
-            tar -czf ../../netpace-${{ steps.get_version.outputs.version }}-${{ matrix.runtime }}${{ steps.deployment_flags.outputs.suffix }}.tar.gz .
+            tar -czf "${archive_stem}.tar.gz" NetPace
           fi
 
       - name: Verify archive contents
@@ -160,7 +162,8 @@ jobs:
           echo "Archive contents:"
           echo "$listing"
           # Every release archive contains exactly one entry — the executable.
-          # AOT: native single binary. Non-AOT: PublishSingleFile=true bundle. DebugType=embedded suppresses side .pdb files.
+          # The Create archive step archives the binary by name, so this verifies the whitelist held and that
+          # the executable was actually present in the publish dir (catches a silent build failure that produced no binary).
           entries=$(echo "$listing" | grep -vE '/$' | grep -c . || true)
           if [ "$entries" -ne 1 ]; then
             echo "FAIL: archive ${archive_stem} must contain exactly 1 entry, found $entries"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,12 +49,19 @@ The AOT binary is named `NetPace` (same as all other variants). On Windows the b
 
 ## Archive-contents contract
 
-Every release archive contains **exactly one entry** — the executable. A "Verify archive contents" workflow step asserts this on every archive before upload; non-zero exit aborts the release.
+Every release archive contains **exactly one entry** — the executable.
 
-How each variant satisfies the contract:
+The "Create archive" workflow step uses a **whitelist** approach: it archives the binary by name (`NetPace.exe` on Windows, `NetPace` elsewhere) rather than zipping/tarring the entire publish directory. All variants are designed to produce a single binary — `-p:PublishSingleFile=true` for non-AOT, native AOT for the AOT variants — but the publish directory also contains toolchain by-products that must not ship to end users:
 
-- **Non-AOT (standalone, net8)** — `-p:PublishSingleFile=true` bundles managed assemblies, runtime config, and native libraries into the host executable. `<DebugType>embedded</DebugType>` in both `NetPace.Console.csproj` and `NetPace.Core.csproj` embeds portable PDBs inside the assembly so no managed `.pdb` side file is produced.
-- **AOT** — native AOT produces a single native binary by design. The Windows linker emits a `.pdb` side file regardless of `DebugType`; the Create archive step scrubs `*.pdb` before zipping. Linux AOT debug info is embedded in the ELF.
+- `NetPace.Core.xml` — emitted because `NetPace.Core.csproj` sets `<GenerateDocumentationFile>true</GenerateDocumentationFile>` for NuGet consumers.
+- `NetPace.pdb` — emitted by the Windows linker for AOT builds regardless of `<DebugType>`.
+- `NetPace.dbg` — emitted by the Linux AOT toolchain when `StripSymbols` is on (the default for Release).
+
+Archiving by name keeps the release contract immune to whatever the next toolchain version decides to emit alongside the binary — no per-extension scrub logic to maintain.
+
+A "Verify archive contents" step asserts the one-entry invariant on every archive before upload as a safety net (it also catches a silent build failure that produced no binary); non-zero exit aborts the release.
+
+`<DebugType>embedded</DebugType>` in both `NetPace.Console.csproj` and `NetPace.Core.csproj` is still set as belt-and-braces — it embeds portable PDBs inside the assembly so the publish directory has no managed `.pdb` side files even for local `dotnet publish` invocations.
 
 End-user CLI binaries don't ship symbols — maintainers reproduce locally with their own debug build. If customer crash-dump symbolication is ever needed, push symbols to a workflow artefact rather than into the user-facing archive.
 


### PR DESCRIPTION
## Summary

- Replaces the extension-based scrub approach (e.g. `rm *.pdb`) in the **Create archive** step with a whitelist: archive the binary by name (`NetPace.exe` / `NetPace`).
- Fixes the underlying cause of the `linux-x64-aot` and `linux-arm64-aot` failures on tag `0.23.2` (stray `NetPace.dbg`) without adding another `rm`-by-extension band-aid that would be due to break again on the next toolchain artefact.
- Updates `docs/RELEASING.md` §Archive-contents contract to describe the whitelist mechanism and call out the by-products it now excludes by construction (`NetPace.Core.xml`, `NetPace.pdb`, `NetPace.dbg`).

## Why this over the targeted `rm -f ./*.dbg` fix

The previous design tried to satisfy "archive contains exactly one entry" through three layered mechanisms (XML doc suppression, `DebugType=embedded`, per-extension `rm` in the workflow). Each new toolchain by-product becomes a new whack-a-mole hit — most recently `NetPace.dbg` on Linux AOT. Whitelisting the binary by name collapses all three to a single concept and immunises the release pipeline against whatever the next toolchain version decides to emit alongside the binary.

The **Verify archive contents** step is retained as a safety net — it now also catches a silent build that produced no binary at all.

## Test plan

- [x] `dotnet build src` clean, 0 warnings, 0 errors locally
- [ ] Push a throwaway tag (e.g. `test-archive-whitelist-0.0.1`) to dry-run all 16 matrix jobs without creating a real GitHub Release; confirm "Verify archive contents" passes for every variant including the previously-broken `linux-x64-aot` and `linux-arm64-aot`; then delete the test tag
- [ ] After merge, the next real release tag should produce 16 archives each containing exactly one entry

Closes the regression first surfaced on tag 0.23.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

nb. This PR attempts to fix the mess caused by: https://github.com/FrankRay78/NetPace/pull/193