### PR TITLE
Guard Speckit Files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -81,7 +81,16 @@
       "Read(**/secrets.*)",
       "Read(**/.ssh/**)",
       "Read(**/appsettings.*.json)",
-      "Read(**/appsettings.json)"
+      "Read(**/appsettings.json)",
+      "Edit(.claude/skills/speckit-*/SKILL.md)",
+      "Write(.claude/skills/speckit-*/SKILL.md)",
+      "MultiEdit(.claude/skills/speckit-*/SKILL.md)",
+      "Edit(.specify/templates/*.md)",
+      "Write(.specify/templates/*.md)",
+      "MultiEdit(.specify/templates/*.md)",
+      "Edit(.specify/scripts/bash/*.sh)",
+      "Write(.specify/scripts/bash/*.sh)",
+      "MultiEdit(.specify/scripts/bash/*.sh)"
     ],
     "ask": [
       "Bash(rm:*)",

--- a/docs/change-intent-records/2026-07-10-guard-speckit-files.md
+++ b/docs/change-intent-records/2026-07-10-guard-speckit-files.md
@@ -1,0 +1,24 @@
+# Guarding Upstream-Managed Spec-Kit Files from Agent Edits
+
+**Intent:** Stop a headless agent (or a stray `specify init --force` regen) from silently mutating the spec-kit files that carry local customizations but are *not* extension points — the failure mode that flipped `disable-model-invocation: true → false` across the SDD skills during the 0.12.10 upgrade.
+
+**Behaviour:**
+- Given: an agent attempts `Edit`/`Write`/`MultiEdit` on a protected file (`.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, or `.specify/scripts/bash/*.sh`)
+- When: the tool call is evaluated against `.claude/settings.json`
+- Then: it is denied, overriding the blanket `Edit(**)`/`Write(**)` allow and `defaultMode: acceptEdits`.
+- Given: an agent edits a genuine extension point (`.specify/templates/overrides/**`, `.specify/extensions/**`, `.specify/memory/constitution.md`, `.specify/feature.json`)
+- Then: the edit is allowed — the deny globs do not match these.
+
+**Constraints:**
+- The protected set mirrors the two spec-kit manifests (`.specify/integrations/{speckit,claude}.manifest.json`): 6 core templates, 5 bash scripts, 10 SDD skills.
+- Extension points must stay editable — deny globs are single-level (`*` never crosses `/`), so `templates/*.md` excludes `templates/overrides/`.
+- Enforcement must cherry-pick cleanly onto downstream (IMS) trees: config-only, no per-clone bootstrap.
+
+**Decisions:**
+1. **`deny`, not `ask`** — a firmer guarantee against headless drift. Trade-off: a deliberate human edit requires temporarily removing the rule. `ask` (human-approvable, headless-blocked) was rejected as too soft for the stated goal.
+2. **`.claude/settings.json` permissions, not a git pre-commit hook or CI check** — the threat is agent edits, so gate at edit-time via the harness. Rejected: git hook (fires late, needs `core.hooksPath` bootstrap, `--no-verify`-able); CI invariant check (catches upgrade-clobber, a manual one-off, not the agent-drift case).
+3. **`speckit-*` glob over enumerating the manifest's exact 10 skills** — a glob survives new SDD skills (e.g. `speckit-converge`) and can't fail open the way a clever character-class exclusion could. Side effect: also protects the 5 `speckit-git-*` extension skills — a harmless, arguably desirable superset.
+
+**Known residual:** the guard covers the `Edit`/`Write`/`MultiEdit` tool path only; a `sed -i`/`git checkout` via `Bash` can still overwrite these files. Out of scope here — a manifest-vs-deny-glob CI check would be the backstop if durable protection is ever needed.
+
+**Date:** 2026-07-10


### PR DESCRIPTION
## Why

Upstream-managed spec-kit files (core templates, bash scripts, the SDD `SKILL.md` skills) carry small local customizations layered on top of the upstream template. A headless agent — or an `specify init --force` regen — can silently overwrite those files with no gate, which is exactly how the `disable-model-invocation: true → false` flip slipped into #214. Nothing in the harness stopped it: `.claude/settings.json` blanket-allows `Edit(**)`/`Write(**)` with `defaultMode: acceptEdits`.

This adds a hard edit-time gate on the files that are **not** designed as extension points.

## What changes

`permissions.deny` rules in `.claude/settings.json` block `Edit`/`Write`/`MultiEdit` on:

- `.claude/skills/speckit-*/SKILL.md` — the 10 SDD skills tracked in `claude.manifest.json` (glob also covers the 5 `speckit-git-*` extension skills, a harmless superset)
- `.specify/templates/*.md` — the 6 core templates
- `.specify/scripts/bash/*.sh` — the 5 core scripts

`deny` overrides the existing blanket allow, so an agent is blocked *before* the edit lands, not at commit time.

## Non-obvious things a reviewer should know

- **The globs deliberately match the two spec-kit manifests' file lists.** `.specify/templates/*.md` and `.specify/scripts/bash/*.sh` are single-level globs (`*` doesn't cross `/`), so genuine extension points stay editable: `.specify/templates/overrides/**`, `.specify/extensions/**`, `constitution.md`, and `feature.json` are untouched by the deny.
- **`speckit-*` over the manifest's exact 10 is intentional.** A glob survives new SDD skills being added (e.g. `speckit-converge`) and can't silently fail open the way a clever character-class exclusion could. Protecting the git-extension skills too is consistent with the goal.
- **Known side door:** this gates the `Edit`/`Write`/`MultiEdit` tool path only. A `sed -i` / `git checkout` via Bash could still mutate these files — out of scope here; a CI content-invariant check would be the backstop if that's ever needed.
- **`deny`, not `ask`, by choice:** a future legitimate hand-edit requires temporarily removing the relevant rule. Chosen over `ask` for a firmer guarantee against headless drift.

## How to verify

- [ ] `jq empty .claude/settings.json` — valid JSON
- [ ] Ask an agent to edit `.claude/skills/speckit-plan/SKILL.md` or `.specify/scripts/bash/common.sh` — the `Edit`/`Write` call is denied
- [ ] Confirm `.specify/templates/overrides/spec-template.md` and `.specify/memory/constitution.md` remain editable (not matched by the single-level globs)

## Related

- Follow-up to #214 (the spec-kit 0.12.10 upgrade whose regen caused the `disable-model-invocation` regression)