### PR TITLE
Agentic Harness Updates

### DIFF
--- a/.claude/hooks/no-skipped-tests.sh
+++ b/.claude/hooks/no-skipped-tests.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# no-skipped-tests.sh — static gate banning the entire skipped-test family (Constitution Principle X).
+#
+# A skipped test reports "green" while checking nothing, so it is silent non-coverage.
+# This gate blocks any `git commit` while a banned construct exists anywhere under src/.
+# Legitimate needs are met without skips: fail loudly on a missing dependency, exclude
+# destructive opt-in suites by [Trait("Category", …)], or document a genuinely untestable
+# branch with a comment at the site.
+#
+# Two modes:
+#   --check        Scan the tree and exit 1 if any banned construct is found (for CI / manual).
+#   (default)      PreToolUse hook: read hook JSON on stdin, block (exit 2) a `git commit`
+#                  that would carry a banned construct.
+#
+# For a commit it is gating, the gate fails CLOSED: if it cannot locate src/, cannot scan, or
+# cannot parse its hook payload (e.g. jq missing), it blocks rather than silently allowing — a
+# gate that fails open is the same silent non-coverage it exists to prevent. These fail-closed
+# guards apply ONLY after the command is classified as a `git commit`; every non-commit Bash call
+# is waved straight through first, so a missing dependency never blocks unrelated commands.
+#
+# Escape hatch (harness-safety rule: override-first, then tighten): set NETPACE_ALLOW_SKIPS=1
+# to bypass. It announces itself on every invocation so it can never be silently in effect.
+# Delete this block once the gate is trusted to make the ban absolute.
+#
+# Wired into .claude/settings.json as a PreToolUse(git commit) hook, so the gate arms
+# automatically on every `git commit`. Constitution Principle X makes the ban itself binding.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Banned constructs: xUnit runtime skips (Skip.If/IfNot/Always/Unless, Assert.Skip), the
+# SkippableFact/Theory family, the static Skip= attribute arg (string OR identifier, e.g.
+# [Fact(Skip = GateReason)]), and SkipException.
+BANNED_RE='Skip\.(If|IfNot|Always|Unless)|Assert\.Skip|Skippable(Fact|Theory)|Skip[[:space:]]*=|SkipException'
+
+# Scan src/ for banned constructs. Returns 0 with matching lines on stdout, 0 with no
+# output when clean, and 2 when the scan itself errored (permission, unreadable tree) so
+# the caller can fail closed instead of reading an error as "clean".
+scan() {
+  local raw status
+  raw="$(grep -rnE --include='*.cs' "$BANNED_RE" "$REPO_ROOT/src")"
+  status=$?
+  # grep: 0 = match, 1 = no match, >=2 = error.
+  if [ "$status" -ge 2 ]; then
+    return 2
+  fi
+  [ -z "$raw" ] && return 0
+  printf '%s\n' "$raw" | grep -vE '/(bin|obj)/'
+  return 0
+}
+
+# Override-first escape hatch — announced, never silent.
+if [ "${NETPACE_ALLOW_SKIPS:-}" = "1" ]; then
+  echo "no-skipped-tests: WARNING — gate BYPASSED via NETPACE_ALLOW_SKIPS=1 (skip ban NOT enforced)." >&2
+  exit 0
+fi
+
+if [ "${1:-}" = "--check" ]; then
+  # Fail closed if we cannot locate the tree to scan (a wrong REPO_ROOT must not read as clean).
+  if [ ! -d "$REPO_ROOT/src" ]; then
+    echo "no-skipped-tests: cannot locate src/ under '$REPO_ROOT' — failing closed (exit 2)." >&2
+    exit 2
+  fi
+  hits="$(scan)"; rc=$?
+  if [ "$rc" -ge 2 ]; then
+    echo "no-skipped-tests: scan of '$REPO_ROOT/src' failed — failing closed (exit 2)." >&2
+    exit 2
+  fi
+  if [ -n "$hits" ]; then
+    echo "Banned skipped-test constructs found:" >&2
+    echo "$hits" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Hook mode: read the PreToolUse JSON on stdin and gate ONLY `git commit`.
+#
+# Classify the command as a commit BEFORE requiring jq or the src/ tree. This hook fires on
+# every Bash call, so a fail-closed dependency check placed ahead of the classification would
+# block unrelated commands (`ls`, `cat`, even `apt install jq`) on any box without jq — a
+# bootstrap deadlock on a fresh machine. The fail-closed guards below therefore apply only once
+# we know this is a commit; a non-commit Bash call is always waved straight through.
+input="$(cat)"
+
+# Cheap, dependency-free pre-filter: if the raw payload cannot even contain a `git commit`, there
+# is nothing to gate — return before touching jq. This deliberately over-matches (any payload
+# mentioning git…commit, including a non-Bash tool editing such text); the precise jq parse below
+# narrows it. It only ever WIDENS what reaches the real check, so no commit can slip past here.
+printf '%s' "$input" | grep -qE '\bgit\b.*\bcommit\b' || exit 0
+
+# jq is required to parse the payload precisely; for a would-be commit a missing jq must fail
+# closed, not wave it through.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED: no-skipped-tests requires jq to parse the hook payload, but jq is not installed — failing closed." >&2
+  exit 2
+fi
+
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')" || {
+  echo "BLOCKED: no-skipped-tests could not parse the hook payload as JSON — failing closed." >&2
+  exit 2
+}
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+
+if [ "$tool" != "Bash" ] || ! printf '%s' "$cmd" | grep -qE '\bgit\b.*\bcommit\b'; then
+  exit 0
+fi
+
+# Confirmed: a Bash `git commit`. Fail closed if we cannot locate the tree to scan.
+if [ ! -d "$REPO_ROOT/src" ]; then
+  echo "BLOCKED: no-skipped-tests cannot locate src/ under '$REPO_ROOT' — failing closed (exit 2)." >&2
+  exit 2
+fi
+
+hits="$(scan)"; rc=$?
+if [ "$rc" -ge 2 ]; then
+  echo "BLOCKED: no-skipped-tests could not scan '$REPO_ROOT/src' — failing closed (exit 2)." >&2
+  exit 2
+fi
+if [ -n "$hits" ]; then
+  {
+    echo "BLOCKED: commit would introduce/retain banned skipped-test constructs."
+    echo "Prohibited: the skip family (Skip.If/IfNot/Always/Unless, Assert.Skip, [Fact/Theory(Skip=…)], [SkippableFact/Theory], SkipException) — see constitution Principle X."
+    echo "Fix: make the test fail loudly, exclude destructive suites by [Trait(\"Category\", …)], or document it with a comment at the site."
+    echo "Offending lines:"
+    echo "$hits"
+    echo "(Emergency override only: NETPACE_ALLOW_SKIPS=1)"
+  } >&2
+  exit 2
+fi
+exit 0

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,3 +15,4 @@
 - [Release-pipeline changes must update docs/RELEASING.md](feedback_release_pipeline_doc.md) — release matrix, runner-per-RID, naming convention, smoke-test contract live there; out-of-sync = future RID work costs extra
 - [Verify-snapshot tests count as coverage in NetPace.Console.Tests](feedback_console_output_snapshot_coverage.md) — check Expectations/*.verified.txt before reporting an output mode as untested
 - [Spec-kit upgrade procedure](speckit_upgrade_procedure.md) — stock github/spec-kit via `specify` CLI; `init --here --force --integration claude --script sh` is additive/hash-guarded
+- [feedback_read_source_before_designing.md](feedback_read_source_before_designing.md) — read the source implementing a subsystem before designing a fix that depends on its behaviour

--- a/.claude/memory/feedback_read_source_before_designing.md
+++ b/.claude/memory/feedback_read_source_before_designing.md
@@ -1,0 +1,11 @@
+---
+name: Read source before designing fixes
+description: Before proposing a fix that depends on how a subsystem behaves, read the source that implements that behaviour. One line of actual code beats three rounds of fix proposals built on a wrong assumption.
+type: feedback
+---
+
+Before designing a fix that depends on how a subsystem behaves, **read the source that implements that behaviour** — not the docs, not your prior mental model, not the test names. Reading the actual code upfront routinely avoids multiple rounds of fix proposals that turn out to be solving the wrong problem.
+
+**Why:** ported from IMS's harness-hardening review (a sibling .NET/spec-kit repo) as a preventive practice, not (yet) from a NetPace-specific incident. In IMS, a subsystem's behaviour was repeatedly guessed at ("the system probably does X") across three iterations of a proposed fix, when reading a single line of the actual implementation would have surfaced the real design gap immediately.
+
+**How to apply:** when a proposed fix rests on "the system does X" / "I believe X happens because...", stop and grep or read the exact code that implements X before sketching the fix. Applies especially to `ISpeedTestService` implementations, provider-specific behaviour in `Clients/{ProviderName}/`, and anywhere a fix is being designed against assumed rather than confirmed behaviour.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -111,6 +111,12 @@
         "hooks": [
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/no-skipped-tests.sh\"",
+            "if": "Bash(git commit:*)",
+            "statusMessage": "Checking for banned skipped-test constructs..."
+          },
+          {
+            "type": "command",
             "command": "STAGED=$(git diff --cached --name-only | grep \"[.]cs$\"); [ -z \"$STAGED\" ] && exit 0; INCLUDE=$(echo \"$STAGED\" | tr '\\n' ' '); dotnet format style --include $INCLUDE && dotnet format whitespace --include $INCLUDE && echo \"$STAGED\" | xargs -d '\\n' git add",
             "if": "Bash(git commit:*)",
             "statusMessage": "Formatting staged .cs files..."

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,16 +1,18 @@
 <!--
 Sync Impact Report:
-Version: 1.3.0 → 1.3.1
-Bump rationale: PATCH — removes a duplicate restatement of "no failing tests or
-build warnings" from Development Workflow > Git Workflow. The rule is retained
-once, in CLAUDE.md's "Working with Claude Code" list (the actionable, Claude-
-facing copy). No principle redefined, no governance change, no new obligation.
+Version: 1.3.1 → 1.4.0
+Bump rationale: MINOR — adds Principle X (No Skipped Tests), a new
+NON-NEGOTIABLE principle banning the xUnit skip-family (Assert.Skip,
+Skip.If/IfNot/Always/Unless, [Fact/Theory(Skip=...)], SkippableFact/Theory).
+Backed by a gate-enforced hook (landing in the next commit), not just guidance.
 
 Modified Principles: N/A
-Added Sections: N/A
-Removed Sections: Git Workflow bullet ("Do not commit code with failing tests or build warnings")
+Added Sections: Principle X — No Skipped Tests (NON-NEGOTIABLE)
+Removed Sections: N/A
 Downstream documents reviewed (per Amendment Process clause 4):
-  ✅ CLAUDE.md — confirmed the rule remains stated there; no change needed.
+  ✅ CLAUDE.md — will get a paired Don't/Do rule referencing this principle in the next commit.
+  ✅ .claude/hooks/no-skipped-tests.sh — new hook enforcing this principle, next commit.
+  ✅ .claude/settings.json — hook wiring, next commit.
 Follow-up TODOs: None
 -->
 
@@ -140,6 +142,19 @@ Acceptance criteria and tests MUST describe outcomes an outside observer can ver
 
 **Downstream references**: detailed avoid/prefer guidance lives in `.claude/commands/speckit.draftissue.md` (AC drafting) and `.claude/commands/speckit.testplan.md` (test scenario authoring). Update those in lockstep with any change to this principle.
 
+### X. No Skipped Tests (NON-NEGOTIABLE)
+
+No test in the suite may be skipped. A skipped test reports green while verifying nothing — silent non-coverage that hides regressions behind a passing run. The entire skip family is prohibited: `[Fact(Skip=…)]` / `[Theory(Skip=…)]`, `Assert.Skip`, `Skip.If` / `Skip.IfNot` / `Skip.Always` / `Skip.Unless`, and `[SkippableFact]` / `[SkippableTheory]`.
+
+**Critical Rules:**
+
+- A missing runtime dependency or unavailable external resource MUST fail loudly, not skip.
+- A destructive or environment-specific opt-in suite MUST be gated by `[Trait("Category", …)]` and excluded by default in the test runner, then included on demand — never conditioned on a runtime skip.
+- A genuinely untestable branch MUST be documented with a comment at the site explaining why (referencing this principle), not silently skipped.
+- Enforcement is a gate, not advisory guidance: `.claude/hooks/no-skipped-tests.sh` blocks any commit introducing a skip-family construct under `src/`, with a `--check` mode for CI/manual scans.
+
+**Rationale**: A skipped test is worse than a missing one — it occupies a coverage slot and shows green, so the gap it leaves is invisible in every report. Making the ban constitutional and gate-enforced keeps the signal honest without relying on anyone remembering not to reach for `Skip`.
+
 ## Development Workflow
 
 ### Git Workflow
@@ -226,4 +241,4 @@ This constitution supersedes all other development practices and guides. All dev
 - Complexity MUST be justified against simplicity principles
 - For runtime development guidance, refer to `CLAUDE.md`
 
-**Version**: 1.3.1 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-07-10
+**Version**: 1.4.0 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-07-10

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,21 +1,16 @@
 <!--
 Sync Impact Report:
-Version: 1.2.0 → 1.3.0
-Bump rationale: MINOR — adds Principle IX (Behavioural Specification) requiring
-ACs and tests to describe outcomes rather than mechanisms. Materially expands
-guidance and gives /speckit.analyze a new enforceable rule; no existing
-principle redefined.
+Version: 1.3.0 → 1.3.1
+Bump rationale: PATCH — removes a duplicate restatement of "no failing tests or
+build warnings" from Development Workflow > Git Workflow. The rule is retained
+once, in CLAUDE.md's "Working with Claude Code" list (the actionable, Claude-
+facing copy). No principle redefined, no governance change, no new obligation.
 
 Modified Principles: N/A
-Added Sections: Principle IX — Behavioural Specification (NON-NEGOTIABLE)
-Removed Sections: N/A
+Added Sections: N/A
+Removed Sections: Git Workflow bullet ("Do not commit code with failing tests or build warnings")
 Downstream documents reviewed (per Amendment Process clause 4):
-  ✅ .claude/commands/speckit.draftissue.md — updated in lockstep (avoid/prefer table + independence test added to step 5)
-  ✅ .claude/commands/speckit.testplan.md — updated in lockstep (mechanism-vs-outcome section + table added before Format)
-  ✅ CLAUDE.md — reviewed; intentionally not duplicated (locality-over-DRY; existing "Don't test" block already covers ad-hoc test writing scope)
-  ✅ .specify/templates/plan-template.md — Principle IX does not affect plan structure
-  ✅ .specify/templates/spec-template.md — Principle IX consumed at AC drafting time via /speckit.draftissue, not in spec template
-  ✅ .specify/templates/tasks-template.md — housekeeping-belongs-in-tasks clarification already implicit
+  ✅ CLAUDE.md — confirmed the rule remains stated there; no change needed.
 Follow-up TODOs: None
 -->
 
@@ -153,7 +148,6 @@ Acceptance criteria and tests MUST describe outcomes an outside observer can ver
 - Commit frequently, especially before refactoring
 - Use clear, concise commit messages in imperative mood
 - Reference issues when applicable: "Fix #123: Handle null server response"
-- Do not commit code with failing tests or build warnings
 
 ### Code Review Standards
 
@@ -232,4 +226,4 @@ This constitution supersedes all other development practices and guides. All dev
 - Complexity MUST be justified against simplicity principles
 - For runtime development guidance, refer to `CLAUDE.md`
 
-**Version**: 1.3.0 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-05-16
+**Version**: 1.3.1 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-07-10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Paired rules — `Don't` X → `Do` Y instead:
 - **Don't hard-wrap markdown prose** → write one line per paragraph, bullet, and table row and let the viewer soft-wrap it; a fixed-column hard wrap reflows the whole block on a one-word edit and buries the real change in a noisy diff.
 - **Don't frame a decision in implementation jargon** → when putting a choice to Frank (an `AskUserQuestion`, a spec tradeoff), lead with plain-language consequences — what it costs, what it unlocks — before the mechanism.
 - **Don't fold a second, unrelated mission into an in-flight branch** → ship the original branch with a documented known-issue and open a separate branch/issue for the new mission instead.
+- **Don't skip a test** (`Assert.Skip`, `Skip.If`/`IfNot`/`Always`/`Unless`, `[Fact(Skip=...)]`, `[SkippableFact]`) → fix it or make it fail loudly instead; blocked by the no-skipped-tests hook (Constitution Principle X).
 
 ## Quick Command Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,9 @@ Paired rules — `Don't` X → `Do` Y instead:
 - **Don't change a CLI option without updating user-facing docs** → README.md `--help` snapshot and USER_GUIDE.md need updating; design-doc cross-ref where applicable. (Per-release "what changed" notes are GitHub-auto-generated from merged PRs — no CHANGELOG.md to maintain.)
 - **Don't change `release-binaries.yml` (or other release-pipeline scope) without updating `docs/RELEASING.md`** → the release matrix, runner-per-RID rationale, naming convention, smoke-test contract, and size-assertion contract live there. Out-of-sync release docs make adding a new RID/variant cost extra.
 - **Don't introduce reflection-heavy or non-trim-safe code** → NetPace targets AOT-trimmable builds (Spectre.Console.Cli was replaced for this reason); avoid runtime reflection, keep types annotation-clean.
+- **Don't hard-wrap markdown prose** → write one line per paragraph, bullet, and table row and let the viewer soft-wrap it; a fixed-column hard wrap reflows the whole block on a one-word edit and buries the real change in a noisy diff.
+- **Don't frame a decision in implementation jargon** → when putting a choice to Frank (an `AskUserQuestion`, a spec tradeoff), lead with plain-language consequences — what it costs, what it unlocks — before the mechanism.
+- **Don't fold a second, unrelated mission into an in-flight branch** → ship the original branch with a documented known-issue and open a separate branch/issue for the new mission instead.
 
 ## Quick Command Reference
 


### PR DESCRIPTION
## Why

A batch of five discrete, independent hardening improvements to NetPace's agentic-development harness, porting practices already proven on a sibling .NET/spec-kit repo (IMS). Each addresses a specific gap: duplicated policy, missing collaboration guidance, an un-captured lesson, and — the substantive one — no enforcement against silently skipped tests.

## What changes

- **Constitution de-duplication** — removed the "no failing tests / build warnings" rule from `Development Workflow > Git Workflow`; it now lives once in CLAUDE.md's actionable "Working with Claude Code" list (constitution `1.3.0 → 1.3.1`).
- **New CLAUDE.md collaboration rules** — no hard-wrapped markdown prose, frame decisions in plain-language consequences before mechanism, and don't fold an unrelated mission into an in-flight branch.
- **New memory entry** — read the source that implements a subsystem before designing a fix that depends on its behaviour.
- **Constitution Principle X — No Skipped Tests (NON-NEGOTIABLE)** — bans the entire xUnit skip family (constitution `1.3.1 → 1.4.0`).
- **Gate hook** — `.claude/hooks/no-skipped-tests.sh` blocks any `git commit` that would introduce a skip-family construct under `src/`, wired first into `settings.json`'s `PreToolUse` chain, plus a `--check` mode for CI/manual scans.

## Non-obvious things a reviewer should know

- **The hook fails *closed*, but only after classifying a command as `git commit`.** Every non-commit Bash call is waved through before any jq/`src/` dependency check runs — this is deliberate, so a box without `jq` can't deadlock on unrelated commands (even `apt install jq`). For an actual commit, a missing `jq`, an unlocatable `src/`, or a scan error blocks rather than silently allowing.
- **Executable bit was set via `git update-index --chmod=+x`, not `chmod`.** `Bash(chmod:*)` is in this repo's `settings.json` deny list, so the filesystem `chmod` is blocked; the committed file mode is `100755` regardless.
- **`NETPACE_ALLOW_SKIPS=1` is an announced escape hatch** — it prints a warning on every invocation so it can never be silently in effect. The header comment marks it for deletion once the gate is trusted.
- **The wired hook only arms on the next session** — harness settings load at session start, so it does not gate commits made in the session that added it. It was validated standalone instead (see below).
- No production `.cs` was touched — this PR is docs, memory, constitution, one shell hook, and settings wiring only.

## How to verify

- [ ] `./.claude/hooks/no-skipped-tests.sh --check` exits `0` on the clean tree.
- [ ] Piping a `git commit` hook payload with no skip present exits `0`; adding a probe line containing `[Fact(Skip = "temp")]` under `src/` and re-piping exits `2` with a `BLOCKED:` message naming Principle X.
- [ ] `settings.json` remains valid JSON and the new entry is first in `PreToolUse[0].hooks`.
- [ ] `dotnet build ./src` is clean (0 warnings, 0 errors). Note: the test *suite* targets .NET 8.0; run it on a machine with the 8.0 runtime installed.