### PR TITLE
chore: Bump Spectre.Console and Spectre.Console.Testing to 0.57.1

### DIFF
--- a/src/NetPace.Console.Tests/NetPace.Console.Tests.csproj
+++ b/src/NetPace.Console.Tests/NetPace.Console.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.57.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />
     <PackageReference Include="Verify" Version="31.12.5" />
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Spectre.Console" Version="0.55.2" />
+    <PackageReference Include="Spectre.Console" Version="0.57.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />
   </ItemGroup>
 	


### PR DESCRIPTION
Bumps `Spectre.Console` and `Spectre.Console.Testing` from 0.55.2 to 0.57.1, aligning both projects together.

Dependabot auto-closed the individual bumps (#209, #210) mid-merge to regroup them into a single update, but hadn't regenerated a replacement — this lands both references at once.

**Verified locally:** build clean (0 warnings), full suite green (616 tests, 0 skipped). The Verify snapshot tests are unchanged by the bump, so 0.57.1 produces identical console output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)