### PR TITLE
Upgrade NetPace from .NET 8 to .NET 10 (LTS) — drops net8.0 TFM (breaking)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore src

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore src

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Extract version from tag
         id: get_version

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Extract version from tag
         id: get_version
@@ -89,7 +89,7 @@ jobs:
             echo "suffix=-aot" >> $GITHUB_OUTPUT
           else
             echo "self_contained=false" >> $GITHUB_OUTPUT
-            echo "suffix=-net8" >> $GITHUB_OUTPUT
+            echo "suffix=-net10" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish Console App

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,18 +1,23 @@
 <!--
 Sync Impact Report:
-Version: 1.3.1 → 1.4.0
-Bump rationale: MINOR — adds Principle X (No Skipped Tests), a new
-NON-NEGOTIABLE principle banning the xUnit skip-family (Assert.Skip,
-Skip.If/IfNot/Always/Unless, [Fact/Theory(Skip=...)], SkippableFact/Theory).
-Backed by a gate-enforced hook (landing in the next commit), not just guidance.
+Version: 1.4.0 → 1.5.0
+Bump rationale: MINOR — updates the mandated target framework from .NET 8.0 to
+.NET 10.0 (the clean LTS→LTS hop; .NET 8 reaches end of support ~November 2026).
+This updates a technology constraint rather than removing or inverting a principle,
+so it is materially updated guidance (MINOR), not a governance redefinition (MAJOR).
+The mandated language baseline is bumped in lockstep to C# 14 (unlocked by .NET 10).
 
-Modified Principles: N/A
-Added Sections: Principle X — No Skipped Tests (NON-NEGOTIABLE)
+Modified Principles: IV — Cross-Platform Compatibility (target .NET 10.0)
+Modified Sections: Technology Constraints → Required Technologies (Framework .NET 10.0, Language C# 14)
+Added Sections: N/A
 Removed Sections: N/A
 Downstream documents reviewed (per Amendment Process clause 4):
-  ✅ CLAUDE.md — will get a paired Don't/Do rule referencing this principle in the next commit.
-  ✅ .claude/hooks/no-skipped-tests.sh — new hook enforcing this principle, next commit.
-  ✅ .claude/settings.json — hook wiring, next commit.
+  ✅ CLAUDE.md — Project Overview / Stack line updated to .NET 10.0 · C# 14.
+  ✅ README.md — build-with line, release-variant name/link, developed-with line updated.
+  ✅ docs/conventions/csharp-style.md — Target Framework line updated to .NET 10.0 (C# 14).
+  ✅ docs/RELEASING.md — framework-dependent artifact name (-net8 → -net10), .NET marker wording, global.json note.
+  ✅ 6 project files + 4 CI workflows — TargetFramework net10.0, SDK pins 10.0.x.
+  ✅ global.json — new SDK pin (10.0.x, rollForward latestFeature).
 Follow-up TODOs: None
 -->
 
@@ -67,7 +72,7 @@ The command-line interface MUST follow industry best practices:
 
 All code MUST run on Windows, Linux, and macOS without platform-specific workarounds:
 
-- Target .NET 8.0 for cross-platform support
+- Target .NET 10.0 for cross-platform support
 - Consider file paths, line endings, console encoding
 - Test on multiple platforms before release
 - Avoid platform-specific APIs unless absolutely necessary
@@ -189,8 +194,8 @@ Before committing, verify:
 
 ### Required Technologies
 
-- **Framework**: .NET 8.0 (cross-platform)
-- **Language**: C# 12
+- **Framework**: .NET 10.0 (cross-platform)
+- **Language**: C# 14
 - **CLI Library**: Spectre.Console
 - **Testing**: xUnit
 - **Package Distribution**: NuGet (NetPace.Core)
@@ -241,4 +246,4 @@ This constitution supersedes all other development practices and guides. All dev
 - Complexity MUST be justified against simplicity principles
 - For runtime development guidance, refer to `CLAUDE.md`
 
-**Version**: 1.4.0 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-07-10
+**Version**: 1.5.0 | **Ratified**: 2026-04-10 | **Last Amended**: 2026-07-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,13 @@ This guide covers **HOW** (NetPace patterns, conventions, gotchas). The constitu
 
 ## Project Overview
 
-NetPace is a cross-platform network speed testing CLI built with .NET 8.0, using Ookla's Speedtest servers.
+NetPace is a cross-platform network speed testing CLI built with .NET 10.0, using Ookla's Speedtest servers.
 
 **Key Components:**
 - `NetPace.Console` — CLI app using Spectre.Console
 - `NetPace.Core` — Reusable library with `ISpeedTestService` interface (published to NuGet)
 
-**Stack:** .NET 8.0 · C# 12 · Spectre.Console · System.CommandLine · xUnit · Nullable reference types enabled
+**Stack:** .NET 10.0 · C# 14 · Spectre.Console · System.CommandLine · xUnit · Nullable reference types enabled
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Network speed tester including server discovery, latency measurement, download and upload speed testing.
 
-Built with .NET 8.0 — runs on Windows, Linux, and macOS.
+Built with .NET 10.0 — runs on Windows, Linux, and macOS.
 
 <p align="left">
     <a href="https://github.com/FrankRay78/NetPace/issues/new?labels=needs%20triage,bug&template=bug-report---.md">Report Bug</a>
@@ -51,11 +51,11 @@ I am no longer the `Spectre.Console` CLI sub-system maintainer, but this project
 ## Getting Started
 Each release contains precompiled binaries you can simply [download](https://github.com/FrankRay78/NetPace/releases), unzip and run. 
 
-Choose from Windows, Linux and macOS; standalone (large file but includes all dependencies), net8 (small file but requires [Microsoft .NET 8.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)) to already be installed, or AOT compiled for bare metal execution (Linux and Windows; macOS AOT remains a future release). 
+Choose from Windows, Linux and macOS; standalone (large file but includes all dependencies), net10 (small file but requires [Microsoft .NET 10.0 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)) to already be installed, or AOT compiled for bare metal execution (Linux and Windows; macOS AOT remains a future release). 
 
 Alternatively, clone this repository locally and build.
 
-Developed with Microsoft .NET 8.0 on Windows 10 using Visual Studio 2022 Community. Other modern environments should work fine.
+Developed with Microsoft .NET 10.0 on Windows 10 using Visual Studio 2022 Community. Other modern environments should work fine.
 
 <br />
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,12 +8,12 @@ Each tag produces one archive per cell of the matrix below — currently 16 (4 N
 
 | Runtime ID | Self-contained | Framework-dependent | Native AOT |
 |------------|----------------|---------------------|------------|
-| `win-x64` | `netpace-{ver}-win-x64-standalone.zip` | `netpace-{ver}-win-x64-net8.zip` | `netpace-{ver}-win-x64-aot.zip` |
-| `win-arm64` | `netpace-{ver}-win-arm64-standalone.zip` | `netpace-{ver}-win-arm64-net8.zip` | `netpace-{ver}-win-arm64-aot.zip` |
-| `linux-x64` | `netpace-{ver}-linux-x64-standalone.tar.gz` | `netpace-{ver}-linux-x64-net8.tar.gz` | `netpace-{ver}-linux-x64-aot.tar.gz` |
-| `linux-arm64` | `netpace-{ver}-linux-arm64-standalone.tar.gz` | `netpace-{ver}-linux-arm64-net8.tar.gz` | `netpace-{ver}-linux-arm64-aot.tar.gz` |
-| `osx-x64` | `netpace-{ver}-osx-x64-standalone.tar.gz` | `netpace-{ver}-osx-x64-net8.tar.gz` | _(out of scope)_ |
-| `osx-arm64` | `netpace-{ver}-osx-arm64-standalone.tar.gz` | `netpace-{ver}-osx-arm64-net8.tar.gz` | _(out of scope)_ |
+| `win-x64` | `netpace-{ver}-win-x64-standalone.zip` | `netpace-{ver}-win-x64-net10.zip` | `netpace-{ver}-win-x64-aot.zip` |
+| `win-arm64` | `netpace-{ver}-win-arm64-standalone.zip` | `netpace-{ver}-win-arm64-net10.zip` | `netpace-{ver}-win-arm64-aot.zip` |
+| `linux-x64` | `netpace-{ver}-linux-x64-standalone.tar.gz` | `netpace-{ver}-linux-x64-net10.tar.gz` | `netpace-{ver}-linux-x64-aot.tar.gz` |
+| `linux-arm64` | `netpace-{ver}-linux-arm64-standalone.tar.gz` | `netpace-{ver}-linux-arm64-net10.tar.gz` | `netpace-{ver}-linux-arm64-aot.tar.gz` |
+| `osx-x64` | `netpace-{ver}-osx-x64-standalone.tar.gz` | `netpace-{ver}-osx-x64-net10.tar.gz` | _(out of scope)_ |
+| `osx-arm64` | `netpace-{ver}-osx-arm64-standalone.tar.gz` | `netpace-{ver}-osx-arm64-net10.tar.gz` | _(out of scope)_ |
 
 ## Naming convention
 
@@ -21,7 +21,7 @@ Each tag produces one archive per cell of the matrix below — currently 16 (4 N
 
 - `version` — semver tag (e.g. `0.6.0`), no `v` prefix.
 - `runtime-id` — .NET RID (`win-x64`, `linux-arm64`, …).
-- `variant` — `standalone` (self-contained), `net8` (framework-dependent), or `aot` (native AOT).
+- `variant` — `standalone` (self-contained), `net10` (framework-dependent), or `aot` (native AOT).
 - `archive-format` — `.zip` for Windows, `.tar.gz` everywhere else.
 
 ## Runner per RID
@@ -82,7 +82,7 @@ Either invariant failing fails the entire release job; no archives are attached.
 
 ## NuGet metadata
 
-The `IsAotCompatible=true` property on `NetPace.Core.csproj` causes `dotnet pack` to emit `[assembly: AssemblyMetadata("IsTrimmable", "True")]` into the packaged DLL — the standard .NET 8 marker NuGet uses to surface AOT compatibility to consumers. The `publish-nuget.yml` workflow is unchanged by this feature and continues to consume the property transparently.
+The `IsAotCompatible=true` property on `NetPace.Core.csproj` causes `dotnet pack` to emit `[assembly: AssemblyMetadata("IsTrimmable", "True")]` into the packaged DLL — the standard .NET marker NuGet uses to surface AOT compatibility to consumers. The `publish-nuget.yml` workflow is unchanged by this feature and continues to consume the property transparently.
 
 ## Conditional NuGet publish
 
@@ -93,6 +93,15 @@ The `IsAotCompatible=true` property on `NetPace.Core.csproj` causes `dotnet pack
 **Consequence**: `NetPace.Core` versions published to nuget.org may skip values (e.g. `0.5.0` → `0.7.0`) when intermediate tags were CLI-only. This is intentional — the published version always reflects a real Core change.
 
 The GitHub Release / binary-attachment flow via `release-binaries.yml` is unaffected and ships every tag.
+
+## SDK version pinning
+
+The .NET SDK version is encoded in two places, both targeting **.NET 10 (LTS)**:
+
+- **`global.json`** (repo root) pins `"version": "10.0.0"` with `"rollForward": "latestFeature"`, so local and CI builds resolve to the latest installed 10.0.x feature band — reproducible without hard-pinning a patch that may not be on every runner.
+- **Each workflow** (`dotnet.yml`, `codeql.yml`, `publish-nuget.yml`, `release-binaries.yml`) sets `dotnet-version: 10.0.x` on `actions/setup-dotnet`, which installs a 10.0 SDK that `global.json` then honours.
+
+When bumping the SDK major, update both places in lockstep.
 
 ## Release notes
 

--- a/docs/conventions/csharp-style.md
+++ b/docs/conventions/csharp-style.md
@@ -124,4 +124,4 @@ Within a class, order members as follows:
 ---
 
 **Last Updated**: April 2026
-**Target Framework**: .NET 8.0 (C# 12)
+**Target Framework**: .NET 10.0 (C# 14)

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Label="Settings">
     <Deterministic>true</Deterministic>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/NetPace.Benchmarks/NetPace.Benchmarks.csproj
+++ b/src/NetPace.Benchmarks/NetPace.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/NetPace.Console.Tests/NetPace.Console.Tests.csproj
+++ b/src/NetPace.Console.Tests/NetPace.Console.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/NetPace.Console/NetPace.Console.csproj
+++ b/src/NetPace.Console/NetPace.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>NetPace</AssemblyName>

--- a/src/NetPace.Core.Tests/NetPace.Core.Tests.csproj
+++ b/src/NetPace.Core.Tests/NetPace.Core.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.cs
@@ -327,7 +327,7 @@ public sealed partial class OoklaSpeedtestTests
         var percentageComplete = new List<int>();
 
         // When
-        var result = await speedtest.GetServerLatencyAsync(server, new Progress<LatencyTestProgress>(progress => percentageComplete.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetServerLatencyAsync(server, new SynchronousProgress<LatencyTestProgress>(progress => percentageComplete.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -355,7 +355,7 @@ public sealed partial class OoklaSpeedtestTests
         cts.CancelAfter(200);
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetServerLatencyAsync(server, new Progress<LatencyTestProgress>(progress => progressReports.Add(progress.PercentageComplete)), cts.Token));
+        var exception = await Record.ExceptionAsync(() => speedtest.GetServerLatencyAsync(server, new SynchronousProgress<LatencyTestProgress>(progress => progressReports.Add(progress.PercentageComplete)), cts.Token));
 
         // Then
         exception.ShouldNotBeNull();
@@ -377,8 +377,11 @@ public sealed partial class OoklaSpeedtestTests
         var server = new Server { Url = "http://testserver.com/", Sponsor = "Sponsor", Location = "Location" };
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetServerLatencyAsync(server, new Progress<LatencyTestProgress>(progress =>
+        var exception = await Record.ExceptionAsync(() => speedtest.GetServerLatencyAsync(server, new SynchronousProgress<LatencyTestProgress>(progress =>
         {
+            // A throwing progress callback is the consumer's bug; OoklaSpeedtest must isolate it
+            // so the measurement still completes. SynchronousProgress runs the throw inline, so
+            // this exercises production isolation (not System.Progress<T>'s async swallowing).
             throw new InvalidOperationException();
         })));
 
@@ -596,7 +599,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -628,7 +631,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -668,7 +671,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetFastestServerByLatencyAsync(servers, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -699,8 +702,11 @@ public sealed partial class OoklaSpeedtestTests
         var servers = new[] { server };
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetFastestServerByLatencyAsync(servers, new Progress<SpeedTestProgress>(progress =>
+        var exception = await Record.ExceptionAsync(() => speedtest.GetFastestServerByLatencyAsync(servers, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
+            // A throwing progress callback is the consumer's bug; OoklaSpeedtest must isolate it
+            // so the measurement still completes. SynchronousProgress runs the throw inline, so
+            // this exercises production isolation (not System.Progress<T>'s async swallowing).
             throw new InvalidOperationException();
         })));
 
@@ -733,7 +739,7 @@ public sealed partial class OoklaSpeedtestTests
         cts.CancelAfter(200);
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetFastestServerByLatencyAsync(servers, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)), cts.Token));
+        var exception = await Record.ExceptionAsync(() => speedtest.GetFastestServerByLatencyAsync(servers, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)), cts.Token));
 
         // Then
         exception.ShouldNotBeNull();
@@ -883,7 +889,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetDownloadSpeedAsync(server, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetDownloadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -948,7 +954,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        await speedtest.GetDownloadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        await speedtest.GetDownloadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
             progressReports.Add(progress.PercentageComplete);
         }));
@@ -984,7 +990,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetDownloadSpeedAsync(server, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetDownloadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -1118,8 +1124,11 @@ public sealed partial class OoklaSpeedtestTests
         var server = new Server { Url = "http://example.com/", Sponsor = "Test", Location = "Test" };
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetDownloadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        var exception = await Record.ExceptionAsync(() => speedtest.GetDownloadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
+            // A throwing progress callback is the consumer's bug; OoklaSpeedtest must isolate it
+            // so the measurement still completes. SynchronousProgress runs the throw inline, so
+            // this exercises production isolation (not System.Progress<T>'s async swallowing).
             throw new InvalidOperationException();
         })));
 
@@ -1150,7 +1159,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<SpeedTestProgress>();
 
         // When
-        await speedtest.GetDownloadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        await speedtest.GetDownloadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
             progressReports.Add(progress);
         }));
@@ -1290,7 +1299,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetUploadSpeedAsync(server, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetUploadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -1352,7 +1361,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        await speedtest.GetUploadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        await speedtest.GetUploadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
             progressReports.Add(progress.PercentageComplete);
         }));
@@ -1397,7 +1406,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<int>();
 
         // When
-        var result = await speedtest.GetUploadSpeedAsync(server, new Progress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
+        var result = await speedtest.GetUploadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress => progressReports.Add(progress.PercentageComplete)));
 
         // Then
         result.ShouldNotBeNull();
@@ -1496,8 +1505,11 @@ public sealed partial class OoklaSpeedtestTests
         var server = new Server { Url = "http://example.com/", Sponsor = "Test", Location = "Test" };
 
         // When
-        var exception = await Record.ExceptionAsync(() => speedtest.GetUploadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        var exception = await Record.ExceptionAsync(() => speedtest.GetUploadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
+            // A throwing progress callback is the consumer's bug; OoklaSpeedtest must isolate it
+            // so the measurement still completes. SynchronousProgress runs the throw inline, so
+            // this exercises production isolation (not System.Progress<T>'s async swallowing).
             throw new InvalidOperationException();
         })));
 
@@ -1529,7 +1541,7 @@ public sealed partial class OoklaSpeedtestTests
         var progressReports = new List<SpeedTestProgress>();
 
         // When
-        await speedtest.GetUploadSpeedAsync(server, new Progress<SpeedTestProgress>(progress =>
+        await speedtest.GetUploadSpeedAsync(server, new SynchronousProgress<SpeedTestProgress>(progress =>
         {
             progressReports.Add(progress);
         }));

--- a/src/NetPace.Core.Tests/SynchronousProgress.cs
+++ b/src/NetPace.Core.Tests/SynchronousProgress.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace NetPace.Core.Tests;
+
+/// <summary>
+/// A synchronous <see cref="IProgress{T}"/> for tests: invokes the handler inline on the
+/// thread that calls <see cref="Report"/>, so collected values reflect the production emit
+/// order deterministically.
+/// </summary>
+/// <remarks>
+/// <see cref="System.Progress{T}"/> is unsuitable for asserting on a progress sequence: it posts
+/// each handler invocation to the captured synchronization context (the thread pool in a unit-test
+/// run), so callbacks can arrive out of order — or even after the awaited operation has returned
+/// and the assertion has already run. That non-determinism was the source of the historic
+/// progress-test flakiness. The Ookla progress paths emit reports in a well-defined order
+/// (sequential loops, or serialised under a lock), so observing them synchronously is exact.
+/// </remarks>
+internal sealed class SynchronousProgress<T> : IProgress<T>
+{
+    private readonly Action<T> handler;
+
+    public SynchronousProgress(Action<T> handler) => this.handler = handler;
+
+    public void Report(T value) => handler(value);
+}

--- a/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
+++ b/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
@@ -101,7 +101,7 @@ public sealed class OoklaSpeedtest : ISpeedTestService
 
             // Report progress after each iteration
             var percentageComplete = (iteration + 1) * 100 / maxIterations;
-            progress.Report(new LatencyTestProgress
+            ReportProgress(progress, new LatencyTestProgress
             {
                 PercentageComplete = percentageComplete,
             });
@@ -172,7 +172,7 @@ public sealed class OoklaSpeedtest : ISpeedTestService
 
             // Report progress after each server is tested
             var percentageComplete = (i + 1) * 100 / servers.Length;
-            progress.Report(new SpeedTestProgress { PercentageComplete = percentageComplete });
+            ReportProgress(progress, new SpeedTestProgress { PercentageComplete = percentageComplete });
         }
 
         // Honour any user cancellations during/after the last probe.
@@ -353,7 +353,7 @@ public sealed class OoklaSpeedtest : ISpeedTestService
                                 // Configured byte cap is hit.
                                 wasCancelledLocally = true;
                                 cts.Cancel();
-                                progress.Report(new SpeedTestProgress
+                                ReportProgress(progress, new SpeedTestProgress
                                 {
                                     PercentageComplete = 100,
                                     BytesProcessed = totalBytesReturned,
@@ -378,7 +378,7 @@ public sealed class OoklaSpeedtest : ISpeedTestService
                                     }
                                 }
 
-                                progress.Report(new SpeedTestProgress
+                                ReportProgress(progress, new SpeedTestProgress
                                 {
                                     PercentageComplete = percentageComplete,
                                     BytesProcessed = totalBytesReturned,
@@ -411,6 +411,25 @@ public sealed class OoklaSpeedtest : ISpeedTestService
     }
 
     #region Static Functions
+
+    /// <summary>
+    /// Reports progress to the consumer, isolating the operation from a throwing callback.
+    /// Progress is best-effort telemetry for the caller's UI; a callback that throws is the
+    /// consumer's bug and MUST NOT fault the running speed test, so its exception is swallowed.
+    /// </summary>
+    private static void ReportProgress<T>(IProgress<T> progress, T value)
+    {
+        try
+        {
+            progress.Report(value);
+        }
+        catch
+        {
+            // Intentionally swallowed: a misbehaving consumer progress callback must never
+            // break the measurement. This is the one legitimate catch-all — isolating
+            // caller-supplied callback code — not a swallowed internal error.
+        }
+    }
 
     private static HttpClient CreateHttpClient(bool useProxy, Uri? proxyAddress, NetworkCredential? proxyCredential)
     {

--- a/src/NetPace.Core/NetPace.Core.csproj
+++ b/src/NetPace.Core/NetPace.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Closes #217.

## Why

.NET 8 (LTS) reaches end of support ~November 2026. .NET 10 is the current LTS (supported to ~November 2028) — this is the clean LTS→LTS hop, skipping .NET 9 (STS).

**Breaking change for `NetPace.Core` consumers.** This is a *single-target* upgrade: `NetPace.Core` drops the `net8.0` TFM rather than multi-targeting. The next NuGet release therefore cannot be restored by a consumer still on .NET 8/9, making it a **MAJOR** bump. Accepted trade-off (fewer than 5 known consumers). The package version is injected from the git tag at pack time, so the MAJOR bump is enacted by tagging the post-merge release accordingly — this PR carries no `<Version>` change. This title/body is deliberately explicit about the break so the auto-generated release notes surface it.

## What changes

**Retarget & toolchain**
- All 6 projects `net8.0 → net10.0`; 4 CI workflow SDK pins `8.0.x → 10.0.x`.
- New `global.json` pinning the SDK to `10.0.0` with `rollForward: latestFeature` for reproducible local/CI builds.

**Governance**
- Constitution amended to mandate .NET 10.0 / C# 14 (Principle IV + Technology Constraints), version `1.4.0 → 1.5.0` (MINOR — a constraint value update, not a principle redefinition), with a rewritten Sync Impact Report listing every downstream doc reviewed.

**Release pipeline & docs**
- Framework-dependent release artifacts renamed `-net8 → -net10`; `docs/RELEASING.md` synced (artifact table, naming convention, `.NET marker` wording) plus a new "SDK version pinning" section documenting `global.json`.
- README (build line, `net10` variant name, runtime download link → `/10.0`), CLAUDE.md (stack line → C# 14), and `csharp-style.md` updated.

**Progress-test determinism + a `NetPace.Core` robustness fix**
- The existing progress tests collected via `System.Progress<T>`, whose async thread-pool dispatch reordered — or dropped-until-after-`await` — its callbacks. Under the .NET 10 scheduler this surfaced as intermittent failures. All 18 progress-collection sites now use a new synchronous `IProgress<T>` test helper, observing production's (already deterministic) emit order exactly.
- Converting the 4 `...ShouldNotPropagateException_WhenProgressCallbackThrows` tests to a synchronous collector revealed they had been passing *by accident* — `Progress<T>` was silently swallowing the thrown callback, not our code. `OoklaSpeedtest` now routes progress reporting through a guarded helper so a throwing consumer callback is isolated for **any** `IProgress<T>` (honouring the intent the production code already documented). Small, backward-compatible internal hardening; no public API signature change.

## Non-obvious things a reviewer should know

- **The guarded catch is a deliberate, documented callback-isolation** — the one legitimate catch-all, not a swallowed internal error. It's a bare `catch` on purpose: Roslynator `RCS1075` flags an empty `catch (Exception)` but not a bare `catch`, and the zero-warning mandate applies.
- **No production race was "fixed" in the ordering tests** — production already emits progress in order (sequential loops / serialised under a lock). The fix was entirely test-side determinism. Root-caused, not re-baselined.
- **3 `net8` mentions remain in the constitution's Sync Impact Report** — intentional historical record of the change *from* .NET 8, not stale references.
- **AOT could not be published locally** (no `clang` on this machine); it reached the native-link step, so the TFM bump didn't break the AOT path. CI runs AOT on the per-RID native runners.

## How to verify

- [ ] `dotnet build ./src -warnaserror` → 0 warnings, 0 errors
- [ ] `dotnet test ./src` green across ~10 consecutive runs (616 tests; proves the progress tests are deterministic, not re-baselined)
- [ ] `dotnet publish src/NetPace.Console -c Release -r linux-x64 --self-contained false -p:PublishSingleFile=true` and the self-contained variant both produce a runnable binary (`./NetPace --version`)
- [ ] `grep -rnE 'net8\.0|\.NET 8|8\.0\.x|dotnet/8\.0|-net8' --include='*.csproj' --include='*.yml' --include='*.md' --include='*.json' . | grep -vE '/(bin|obj)/'` returns only the 3 intentional Sync-Impact-Report mentions
- [ ] Confirm the guarded-callback behaviour reads as intended in `OoklaSpeedtest.ReportProgress`

## Related

- Issue #217 (self-contained upgrade brief)
