### PR TITLE
Add /ship: verify → review → raise orchestrator (#223)

### DIFF
--- a/.claude/commands/capture-learnings.md
+++ b/.claude/commands/capture-learnings.md
@@ -33,7 +33,9 @@ Run this command at the end of a working session, after completing a feature, or
    - User said: "yes exactly", "perfect", "keep doing that", "that's the right approach"
    - User accepted an unusual or counter-intuitive decision without pushback
 
-3. **Gather git corroboration** (secondary source — only when `has_branch_context` is true): Run:
+3. **Gather corroboration from git and any open PR** (secondary sources): two independent sources, gated separately.
+
+   **Git corroboration — only when `has_branch_context` is true.** Run:
    - `git log <default>..HEAD --oneline --reverse`
    - `git diff <default>...HEAD --name-status`
 
@@ -41,9 +43,9 @@ Run this command at the end of a working session, after completing a feature, or
    - Renamed or moved files (R status) — especially CLAUDE.md, docs, or config files
    - Modifications to `CLAUDE.md` or `.specify/memory/constitution.md`
 
-   When `has_branch_context` is false (running on the default branch, or feature branch with no commits yet), skip this step — only Confidence levels reachable in step 5 are `Medium (chat only)`.
+   When `has_branch_context` is false (running on the default branch, or feature branch with no commits yet), skip the git commands above — the only Confidence level reachable in step 5 is then `Medium (chat only)`.
 
-   **PR review source (unconditional, best-effort — runs regardless of `has_branch_context`)**: if the current branch has an open PR, fetch its review via `gh pr view --json comments,reviews` and route each substantive point through the same enforceability triage (step 4) as a conversation signal. This is best-effort and never a hard step: a no-op when no PR or no review exists (which is the normal case seconds after PR creation, e.g. when composed by `/ship`), and a genuine source when a posted `@claude` review is already on the PR (the normal case running `/capture-learnings` standalone later). Do **not** wait or poll for a review that has not posted yet.
+   **PR review — unconditional, best-effort** (independent of `has_branch_context`; runs even when the git corroboration above is skipped): if the current branch has an open PR, fetch its review via `gh pr view --json comments,reviews` and route each substantive point through the same enforceability triage (step 4) as a conversation signal. Best-effort and never a hard step: a no-op when no PR or no review exists (the normal case seconds after PR creation, e.g. when composed by `/ship`), and a genuine source when a posted `@claude` review is already on the PR (the normal case running `/capture-learnings` standalone later). Do **not** wait or poll for a review that has not posted yet.
 
 4. **Prefer deterministic enforcement over a memory entry, where the learning allows it**: A memory entry is a *rule Claude must remember* — it costs context every session and only works when recall lands and Claude honours it. A hook, `settings.json` change, lint rule, or architectural/unit test enforces the same learning *deterministically*: zero tokens, cannot be forgotten, fails loud. NetPace already leans this way — the constitution makes TDD non-negotiable so the test suite (not a reminder) is what stops regressions, and speckit git hooks are wired in `settings.json` rather than left to Claude to remember.
 

--- a/.claude/commands/capture-learnings.md
+++ b/.claude/commands/capture-learnings.md
@@ -43,6 +43,8 @@ Run this command at the end of a working session, after completing a feature, or
 
    When `has_branch_context` is false (running on the default branch, or feature branch with no commits yet), skip this step — only Confidence levels reachable in step 5 are `Medium (chat only)`.
 
+   **PR review source (unconditional, best-effort — runs regardless of `has_branch_context`)**: if the current branch has an open PR, fetch its review via `gh pr view --json comments,reviews` and route each substantive point through the same enforceability triage (step 4) as a conversation signal. This is best-effort and never a hard step: a no-op when no PR or no review exists (which is the normal case seconds after PR creation, e.g. when composed by `/ship`), and a genuine source when a posted `@claude` review is already on the PR (the normal case running `/capture-learnings` standalone later). Do **not** wait or poll for a review that has not posted yet.
+
 4. **Prefer deterministic enforcement over a memory entry, where the learning allows it**: A memory entry is a *rule Claude must remember* — it costs context every session and only works when recall lands and Claude honours it. A hook, `settings.json` change, lint rule, or architectural/unit test enforces the same learning *deterministically*: zero tokens, cannot be forgotten, fails loud. NetPace already leans this way — the constitution makes TDD non-negotiable so the test suite (not a reminder) is what stops regressions, and speckit git hooks are wired in `settings.json` rather than left to Claude to remember.
 
    This triage by **enforceability** is the lens step 5 applies to each candidate before assigning its target — three classes:

--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -17,16 +17,10 @@ Read `CLAUDE.md` for project context before proceeding.
 
    Otherwise parse `FEATURE_DIR` from the JSON output. If `FEATURE_DIR` does not exist on disk, skip to step 5. Otherwise keep it for step 4.
 
-4. **Confirm and delete spec folder**: Use `AskUserQuestion` to ask:
-   - Question: "Delete the spec folder `<FEATURE_DIR>` and commit the removal? Specs are typically deleted before merge so they don't accumulate on main."
-   - Options: "Delete and commit" / "Skip"
-
-   If "Delete and commit":
+4. **Delete spec folder**: Specs are deleted before merge so they don't accumulate on `main`, so remove `<FEATURE_DIR>` and commit the removal without prompting (this keeps `/raise-pr` composable by `/ship` with no interactive gate):
    - Run `git rm -r <FEATURE_DIR>`
    - Clear the spec-kit feature pointer so it doesn't dangle at a deleted folder on `main`: if `.specify/feature.json` exists and its `feature_directory` points at `<FEATURE_DIR>`, reset it to `{"feature_directory": ""}` and `git add .specify/feature.json`. (A stale pointer makes `check-prerequisites.sh` hard-fail and lets `setup-plan.sh` silently recreate the deleted folder.)
    - Run `git commit -m "chore: remove <FEATURE_DIR>"`
-
-   If "Skip", proceed without changes.
 
 5. **Infer PR title**: Take the branch name from step 1, strip any leading path segment (`feat/`, `fix/`, `chore/`, `docs/`, etc.), strip any leading `NNN-` numeric prefix on the remaining segment, replace hyphens with spaces, and apply title case. Examples: `004-raise-pr-command` → `Raise PR Command`; `chore/speckit-docs-tidy` → `Speckit Docs Tidy`.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -15,7 +15,7 @@ Read `CLAUDE.md` for project context before proceeding.
 0. **Preconditions (before any suite run or review).**
    - Run `git rev-parse --abbrev-ref HEAD`. If it is `main`, STOP immediately and report: "Run /ship from a feature branch, not main." Do not run the suite, do not spawn reviewers.
    - Run `git log main..HEAD --oneline`. If empty, STOP immediately and report: "No commits on this branch over main — nothing to ship." Do not run the suite or spawn reviewers.
-   - Capture the working-tree baseline so step 3 can tell review edits apart from pre-existing local changes: record `git status --short` and the tracked-tree content hash `git diff HEAD | git hash-object --stdin` as `PRE_HASH`. A dirty tree is allowed but note it in the final report.
+   - Capture the working-tree baseline so step 3 can detect what the review changed: snapshot the **whole** working tree — tracked content *and* untracked files — as `PRE_HASH = { git diff HEAD; git status --short; } | git hash-object --stdin`. `git diff HEAD` captures tracked content (incl. staged, and further edits to an already-dirty file); `git status --short` adds the presence of new untracked files, which `git diff HEAD` alone omits. A dirty tree is allowed but note it in the final report.
 
    The precondition guard runs up front deliberately: `/raise-pr`'s own late branch check must not be the first line of defence, or the full suite and full review would run pointlessly first.
 
@@ -34,11 +34,11 @@ Read `CLAUDE.md` for project context before proceeding.
    Apply the warranted edits to the working tree. Every applied edit is re-verified by step 3's suite re-run, so a bad fix cannot ship green-unchecked.
    - If a review subagent errors, STOP and report (stop-on-failure).
 
-3. **Conditional re-verify + commit the fixes.** Detect whether step 2 changed tracked code by a **content diff of the whole tracked working tree**, not a `*.cs`-only `git status` filter: compute `POST_HASH = git diff HEAD | git hash-object --stdin` and compare to `PRE_HASH` from step 0. This covers **all** tracked files (`.cs`, `.csproj`, `Directory.Packages.props`, `.json`, …) and correctly ignores files that were already dirty before step 2. Never use a marker mtime.
+3. **Conditional re-verify + commit the fixes.** Detect whether step 2 changed anything by re-computing the step-0 whole-tree snapshot — `POST_HASH = { git diff HEAD; git status --short; } | git hash-object --stdin` — and comparing to `PRE_HASH`. Hashing `git diff HEAD` covers tracked content across **all** file types (`.cs`, `.csproj`, `Directory.Packages.props`, `.json`, …) and distinguishes a further edit to an already-dirty file; adding `git status --short` covers **new untracked files** a review may create (a new test, an extracted helper) — which `git diff HEAD` alone silently omits, and missing one means the fix never reaches the PR. Never a `*.cs`-only filter, never a marker mtime.
    - **If `POST_HASH == PRE_HASH` (step 2 changed nothing):** skip both the re-run and the commit — go to step 4. (No spurious second suite run.)
    - **If `POST_HASH != PRE_HASH` (step 2 applied edits):**
      - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.
-     - Once green, **commit the applied edits** with a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted working-tree edits would silently never ship. If the baseline tree was already dirty, stage only the review edits, not unrelated pre-existing local changes.
+     - Once green, **commit the applied edits** with a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted or untracked working-tree edits would silently never ship. Stage **the specific paths step 2's loop edited or created** (`git add <those paths>` — the loop knows them, and this includes any new files), not `git add -A`; on an already-dirty baseline this keeps unrelated pre-existing changes out of the commit without needing to isolate hunks.
 
 4. **Raise the PR (final step).** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here and report.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,12 +1,12 @@
 ---
-description: Human-invoked orchestrator that turns "implementation looks done" into a reviewed, test-green pull request — runs the full suite first and hard-gates on it, then reviews, commits warranted fixes, raises the PR, and captures learnings.
+description: Orchestrator that turns "implementation looks done" into a reviewed, test-green pull request — runs the full suite first and hard-gates on it, then reviews, fixes every confirmed Blocker/Important finding, and raises the PR. Runs unattended, so it can drive a loop.
 ---
 
 Read `CLAUDE.md` for project context before proceeding.
 
 `/ship` composes NetPace's existing commands behind one hard gate: **the full test suite runs first, and nothing downstream happens unless it is green.** The gate is structural — the review step is downstream of the step-1 exit code, so it cannot begin against un-verified or red code. Do not add a hook to police this ordering; the exit code *is* the gate.
 
-`/ship` is human-invoked and supervised. Composed steps MAY prompt you (e.g. `/capture-learnings`) — running fully unattended is a non-goal.
+`/ship` is designed to run to completion **without prompting**, so it can be driven by an automated loop (e.g. shipping many features back-to-back) as well as invoked directly. Reflection (`/capture-learnings`) is deliberately **not** a step: it needs human curation and batches better across many features, so it belongs at a supervised checkpoint after a batch — not inside each ship, where it would either block the loop or be auto-skipped to nothing. `/ship` likewise never waits on the async `@claude` PR review (see below).
 
 **Stop-on-failure is global:** if any step fails — a suite run is not green, a review subagent errors, `git push` is rejected, `gh pr create` fails because the PR already exists — STOP at that step, report it to the invoker, and do not run any later step.
 
@@ -27,7 +27,11 @@ Read `CLAUDE.md` for project context before proceeding.
 2. **Clean-context review (synchronous — this is Review A).** Spawn independent, clean-context reviewer subagents over the branch diff (`git diff main...HEAD`), then run a `/review-slop` pass. The clean-context subagents must not see the code being written — "do not inline the review" governs the *reviewing*. The *deciding-and-fixing* legitimately happens in `/ship`'s own main loop.
    - Spawn the `pr-review-toolkit` reviewers that apply to this diff. Most **report** findings — `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `type-design-analyzer`, `comment-analyzer` return findings; only `code-simplifier` edits files directly. Launch them in parallel (independent, clean-context Task subagents).
    - Run `/review-slop`, which emits a cleaned diff.
-   - **`/ship`'s main loop then decides.** Take the returned findings and cleaned diff, decide which warrant a change, and apply those edits to the working tree. The subagents' returned summaries landing in this loop's context is exactly how the findings reach step 5 — do not discard them.
+   - **`/ship`'s main loop applies a severity policy.** Aggregate the returned findings and cleaned diff. For each finding, first *validate it is real* — reviewer severities are fickle, so do not act on a mislabelled or false-positive finding — then act by severity:
+     - **Blocker / P1** (a correctness bug, breakage, or anything that would ship broken) — **must be resolved.** Fix it in the working tree. If a confirmed blocker genuinely cannot be fixed, **STOP and report**; `/ship` never raises a PR over a known blocker.
+     - **Important / P2** — fix it **when it is within the scope of this change** (the branch's own new or edited code). If a confirmed P2 concerns *pre-existing or adjacent* code the branch did not cause, do **not** force-fix it here — that folds an unrelated mission into the branch; record it in the PR body or as a follow-up instead.
+     - **Suggestion / P3** — discretionary: apply if cheap and clearly correct, otherwise skip.
+   Apply the warranted edits to the working tree. Every applied edit is re-verified by step 3's suite re-run, so a bad fix cannot ship green-unchecked.
    - If a review subagent errors, STOP and report (stop-on-failure).
 
 3. **Conditional re-verify + commit the fixes.** Detect whether step 2 changed tracked code by a **content diff of the whole tracked working tree**, not a `*.cs`-only `git status` filter: compute `POST_HASH = git diff HEAD | git hash-object --stdin` and compare to `PRE_HASH` from step 0. This covers **all** tracked files (`.cs`, `.csproj`, `Directory.Packages.props`, `.json`, …) and correctly ignores files that were already dirty before step 2. Never use a marker mtime.
@@ -36,16 +40,15 @@ Read `CLAUDE.md` for project context before proceeding.
      - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.
      - Once green, **commit the applied edits** with a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted working-tree edits would silently never ship. If the baseline tree was already dirty, stage only the review edits, not unrelated pre-existing local changes.
 
-4. **Raise the PR.** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here — do not run step 5.
+4. **Raise the PR (final step).** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here and report.
 
-5. **Capture learnings (synchronous sources only).** Run `/capture-learnings` over the session and git. Its inputs are the conversation (which now holds step 2's returned review findings) plus git — the **synchronous** Review A. `/ship` does **not** wait for, and does **not** prompt about, the asynchronous `@claude` PR review from step 4 (Review B); behaviour is identical whether or not that GitHub action posts.
-   - `/ship`'s final output MAY carry a single soft nudge — "the `@claude` PR review posts async; re-run `/capture-learnings` if it flags something notable" — a free reminder, never a gate or a wait.
+   `/ship` ends at the raised PR. It does **not** run `/capture-learnings`, and does **not** wait on or prompt about the async `@claude` review (Review B, see below). Its closing output carries one soft nudge — "PR raised; the `@claude` review posts async — run `/capture-learnings` when you next review the batch" — a free reminder, never a gate or a wait.
 
 ## The two reviews (Review A vs Review B)
 
-- **Review A** — step 2, synchronous, in-`/ship`: the clean-context `pr-review-toolkit` subagents + `/review-slop`. Its findings are in-context and its fixes are committed by the time step 5 runs. This is capture-learnings' input.
-- **Review B** — step 4, asynchronous, on the PR: the `@claude` GitHub-action review `/raise-pr` requests, posting minutes after `/ship` has returned. `/ship` never waits on it — polling a supervised flow for minutes buys little durable *lesson*, and the action is author-gated (`claude.yml`) so it doesn't even post for a non-`FrankRay78` invoker. Review B is for a human to read at merge, not an input to `/capture-learnings`.
+- **Review A** — step 2, synchronous, in-`/ship`: the clean-context `pr-review-toolkit` subagents + `/review-slop`. Its findings drive the step-2 fixes and are committed in step 3 — that is how the review shapes the PR before it is raised.
+- **Review B** — step 4, asynchronous, on the PR: the `@claude` GitHub-action review `/raise-pr` requests, posting minutes after `/ship` has returned. `/ship` never waits on it — it is author-gated (`claude.yml`) so it doesn't even post for a non-`FrankRay78` invoker, and blocking a pipeline for minutes to fold it in buys little. Review B is for a human to read at merge; when you later run `/capture-learnings` at a supervised checkpoint, that command's own best-effort PR-review fetch picks it up then.
 
 ## Final report
 
-Report to the invoker: the suite result(s), which review findings were applied and committed (if any), the PR URL, and the capture-learnings outcome. If the working tree was dirty at step 0, say so.
+Report to the invoker: the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge. If the working tree was dirty at step 0, say so.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,55 @@
+---
+description: Human-invoked orchestrator that turns "implementation looks done" into a reviewed, test-green pull request — runs the full suite first and hard-gates on it, then reviews, commits warranted fixes, raises the PR, and captures learnings.
+---
+
+Read `CLAUDE.md` for project context before proceeding.
+
+`/ship` composes NetPace's existing commands behind one hard gate: **the full test suite runs first, and nothing downstream happens unless it is green.** The steps below are ordered and the gate between step 1 and step 2 is structural — the review step is downstream of the test run's success, so it cannot begin unless step 1 exited green. Do not add a hook to police this ordering; the exit code *is* the gate.
+
+`/ship` is human-invoked and supervised. Composed steps MAY prompt you (e.g. `/capture-learnings`) — running fully unattended is a non-goal.
+
+**Stop-on-failure is global:** if any step fails — a suite run is not green, a review subagent errors, `git push` is rejected, `gh pr create` fails because the PR already exists — STOP at that step, report it to the invoker, and do not run any later step.
+
+## Steps
+
+0. **Preconditions (before any suite run or review).**
+   - Run `git rev-parse --abbrev-ref HEAD`. If it is `main`, STOP immediately and report: "Run /ship from a feature branch, not main." Do not run the suite, do not spawn reviewers.
+   - Run `git log main..HEAD --oneline`. If empty, STOP immediately and report: "No commits on this branch over main — nothing to ship." Do not run the suite or spawn reviewers.
+   - Capture the working-tree baseline so step 3 can tell review edits apart from pre-existing local changes: record `git status --short` and the tracked-tree content hash `git diff HEAD | git hash-object --stdin` as `PRE_HASH`. A dirty tree is allowed but note it in the final report.
+
+   The precondition guard runs up front deliberately: `/raise-pr`'s own late branch check must not be the first line of defence, or the full suite and full review would run pointlessly first.
+
+1. **Full test run (always).** Run `dotnet build ./src && dotnet test ./src` — always, including docs-only branches. Do not add a skip path for docs-only branches: the suite is fast, and the always-on `gh pr create` `PreToolUse` hook re-runs it at step 4 anyway, so a skip saves nothing and could let review run before a late hook-block.
+   - Gate on the run's **exit code**, not on any stored marker.
+   - **Not green ⇒ STOP:** report the failures to the invoker and do nothing else — no review subagents, no PR.
+   - **Green ⇒ continue.**
+
+2. **Clean-context review (synchronous — this is Review A).** Spawn independent, clean-context reviewer subagents over the branch diff (`git diff main...HEAD`), then run a `/review-slop` pass. The clean-context subagents must not see the code being written — "do not inline the review" governs the *reviewing*. The *deciding-and-fixing* legitimately happens in `/ship`'s own main loop.
+   - Spawn the `pr-review-toolkit` reviewers that apply to this diff. Most **report** findings — `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `type-design-analyzer`, `comment-analyzer` return findings; only `code-simplifier` edits files directly. Launch them in parallel (independent, clean-context Task subagents).
+   - Run `/review-slop`, which emits a cleaned diff.
+   - **`/ship`'s main loop then decides.** Take the returned findings and cleaned diff, decide which warrant a change, and apply those edits to the working tree. The subagents' returned summaries landing in this loop's context is exactly how the findings reach step 5 — do not discard them.
+   - If a review subagent errors, STOP and report (stop-on-failure).
+
+3. **Conditional re-verify + commit the fixes.** Detect whether step 2 changed tracked code by a **content diff of the whole tracked working tree**, not a `*.cs`-only `git status` filter: compute `POST_HASH = git diff HEAD | git hash-object --stdin` and compare to `PRE_HASH` from step 0. This covers **all** tracked files (`.cs`, `.csproj`, `Directory.Packages.props`, `.json`, …) and correctly ignores files that were already dirty before step 2. Never use a marker mtime.
+   - **If `POST_HASH == PRE_HASH` (step 2 changed nothing):** skip both the re-run and the commit — go to step 4. (No spurious second suite run.)
+   - **If `POST_HASH != PRE_HASH` (step 2 applied edits):**
+     - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.
+     - Once green, **commit the applied edits** with a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted working-tree edits would silently never ship. If the baseline tree was already dirty, stage only the review edits, not unrelated pre-existing local changes.
+
+4. **Raise the PR.** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here — do not run step 5.
+
+5. **Capture learnings (synchronous sources only).** Run `/capture-learnings` over the session and git. Its inputs are the conversation (which now holds step 2's returned review findings) plus git — the **synchronous** Review A. `/ship` does **not** wait for, and does **not** prompt about, the asynchronous `@claude` PR review from step 4 (Review B); behaviour is identical whether or not that GitHub action posts.
+   - `/ship`'s final output MAY carry a single soft nudge — "the `@claude` PR review posts async; re-run `/capture-learnings` if it flags something notable" — a free reminder, never a gate or a wait.
+
+## Why capture-learnings feeds from the synchronous review, not the async one
+
+`/ship` runs two reviews:
+
+- **Review A (step 2, synchronous, in-`/ship`):** the clean-context `pr-review-toolkit` subagents + `/review-slop`. Its findings are in-context, and the fixes derived from them are committed in git, the moment step 5 runs.
+- **Review B (step 4, asynchronous, on the PR):** the `@claude` GitHub-action review `/raise-pr` requests. It posts minutes later, after `/ship` has returned.
+
+The review → memory loop closes inside a single `/ship` run via Review A. Waiting on Review B would turn a responsive supervised flow into a minutes-long poll for marginal gain, and it does not even post for a non-`FrankRay78` invoker (the `claude.yml` job is author-gated). Review B still lands on the PR for a human to read at merge — that is its audience; it is not an input to `/capture-learnings`.
+
+## Final report
+
+Report to the invoker: the suite result(s), which review findings were applied and committed (if any), the PR URL, and the capture-learnings outcome. If the working tree was dirty at step 0, say so.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -4,7 +4,7 @@ description: Human-invoked orchestrator that turns "implementation looks done" i
 
 Read `CLAUDE.md` for project context before proceeding.
 
-`/ship` composes NetPace's existing commands behind one hard gate: **the full test suite runs first, and nothing downstream happens unless it is green.** The steps below are ordered and the gate between step 1 and step 2 is structural — the review step is downstream of the test run's success, so it cannot begin unless step 1 exited green. Do not add a hook to police this ordering; the exit code *is* the gate.
+`/ship` composes NetPace's existing commands behind one hard gate: **the full test suite runs first, and nothing downstream happens unless it is green.** The gate is structural — the review step is downstream of the step-1 exit code, so it cannot begin against un-verified or red code. Do not add a hook to police this ordering; the exit code *is* the gate.
 
 `/ship` is human-invoked and supervised. Composed steps MAY prompt you (e.g. `/capture-learnings`) — running fully unattended is a non-goal.
 
@@ -41,14 +41,10 @@ Read `CLAUDE.md` for project context before proceeding.
 5. **Capture learnings (synchronous sources only).** Run `/capture-learnings` over the session and git. Its inputs are the conversation (which now holds step 2's returned review findings) plus git — the **synchronous** Review A. `/ship` does **not** wait for, and does **not** prompt about, the asynchronous `@claude` PR review from step 4 (Review B); behaviour is identical whether or not that GitHub action posts.
    - `/ship`'s final output MAY carry a single soft nudge — "the `@claude` PR review posts async; re-run `/capture-learnings` if it flags something notable" — a free reminder, never a gate or a wait.
 
-## Why capture-learnings feeds from the synchronous review, not the async one
+## The two reviews (Review A vs Review B)
 
-`/ship` runs two reviews:
-
-- **Review A (step 2, synchronous, in-`/ship`):** the clean-context `pr-review-toolkit` subagents + `/review-slop`. Its findings are in-context, and the fixes derived from them are committed in git, the moment step 5 runs.
-- **Review B (step 4, asynchronous, on the PR):** the `@claude` GitHub-action review `/raise-pr` requests. It posts minutes later, after `/ship` has returned.
-
-The review → memory loop closes inside a single `/ship` run via Review A. Waiting on Review B would turn a responsive supervised flow into a minutes-long poll for marginal gain, and it does not even post for a non-`FrankRay78` invoker (the `claude.yml` job is author-gated). Review B still lands on the PR for a human to read at merge — that is its audience; it is not an input to `/capture-learnings`.
+- **Review A** — step 2, synchronous, in-`/ship`: the clean-context `pr-review-toolkit` subagents + `/review-slop`. Its findings are in-context and its fixes are committed by the time step 5 runs. This is capture-learnings' input.
+- **Review B** — step 4, asynchronous, on the PR: the `@claude` GitHub-action review `/raise-pr` requests, posting minutes after `/ship` has returned. `/ship` never waits on it — polling a supervised flow for minutes buys little durable *lesson*, and the action is author-gated (`claude.yml`) so it doesn't even post for a non-`FrankRay78` invoker. Review B is for a human to read at merge, not an input to `/capture-learnings`.
 
 ## Final report
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -15,7 +15,7 @@ Read `CLAUDE.md` for project context before proceeding.
 0. **Preconditions (before any suite run or review).**
    - Run `git rev-parse --abbrev-ref HEAD`. If it is `main`, STOP immediately and report: "Run /ship from a feature branch, not main." Do not run the suite, do not spawn reviewers.
    - Run `git log main..HEAD --oneline`. If empty, STOP immediately and report: "No commits on this branch over main — nothing to ship." Do not run the suite or spawn reviewers.
-   - Capture the working-tree baseline so step 3 can detect what the review changed: snapshot the **whole** working tree — tracked content *and* untracked files — as `PRE_HASH = { git diff HEAD; git status --short; } | git hash-object --stdin`. `git diff HEAD` captures tracked content (incl. staged, and further edits to an already-dirty file); `git status --short` adds the presence of new untracked files, which `git diff HEAD` alone omits. A dirty tree is allowed but note it in the final report.
+   - Require a **clean working tree**. Run `git status --porcelain`; if it is non-empty, STOP and report: "Commit or stash your changes before shipping." A clean tree is what makes step 3 simple and correct: after the review, *anything* that shows up in the tree is a review edit and nothing else, so there is no need to separate review edits from pre-existing local changes.
 
    The precondition guard runs up front deliberately: `/raise-pr`'s own late branch check must not be the first line of defence, or the full suite and full review would run pointlessly first.
 
@@ -34,11 +34,11 @@ Read `CLAUDE.md` for project context before proceeding.
    Apply the warranted edits to the working tree. Every applied edit is re-verified by step 3's suite re-run, so a bad fix cannot ship green-unchecked.
    - If a review subagent errors, STOP and report (stop-on-failure).
 
-3. **Conditional re-verify + commit the fixes.** Detect whether step 2 changed anything by re-computing the step-0 whole-tree snapshot — `POST_HASH = { git diff HEAD; git status --short; } | git hash-object --stdin` — and comparing to `PRE_HASH`. Hashing `git diff HEAD` covers tracked content across **all** file types (`.cs`, `.csproj`, `Directory.Packages.props`, `.json`, …) and distinguishes a further edit to an already-dirty file; adding `git status --short` covers **new untracked files** a review may create (a new test, an extracted helper) — which `git diff HEAD` alone silently omits, and missing one means the fix never reaches the PR. Never a `*.cs`-only filter, never a marker mtime.
-   - **If `POST_HASH == PRE_HASH` (step 2 changed nothing):** skip both the re-run and the commit — go to step 4. (No spurious second suite run.)
-   - **If `POST_HASH != PRE_HASH` (step 2 applied edits):**
+3. **Conditional re-verify + commit the fixes.** Because step 0 required a clean tree, `git status --porcelain` now shows exactly what step 2 changed — from *any* source (the loop's own fixes **and** any files `code-simplifier` edited directly) — and nothing else.
+   - **If `git status --porcelain` is empty (step 2 changed nothing):** skip both the re-run and the commit — go to step 4. (No spurious second suite run.)
+   - **If it is non-empty (step 2 applied edits):**
      - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.
-     - Once green, **commit the applied edits** with a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted or untracked working-tree edits would silently never ship. Stage **the specific paths step 2's loop edited or created** (`git add <those paths>` — the loop knows them, and this includes any new files), not `git add -A`; on an already-dirty baseline this keeps unrelated pre-existing changes out of the commit without needing to isolate hunks.
+     - Once green, **commit the edits** with `git add -A` and a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted or untracked working-tree edits would silently never ship. `git add -A` is correct and complete here precisely because the tree started clean: it stages every review edit (including new untracked files and deletions) with no risk of sweeping in unrelated local changes.
 
 4. **Raise the PR (final step).** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here and report.
 
@@ -51,4 +51,4 @@ Read `CLAUDE.md` for project context before proceeding.
 
 ## Final report
 
-Report to the invoker: the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge. If the working tree was dirty at step 0, say so.
+Report to the invoker: the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge.


### PR DESCRIPTION
## Why

Closes #223. NetPace already had every ingredient a supervised ship flow composes — `/raise-pr`, `/review-slop`, `/capture-learnings`, and the `pr-review-toolkit` plugin — but nothing wired them behind a single hard **test-green** gate. Today that's 3+ separate manual invocations. `/ship` is the orchestrator that chains them so review and PR creation cannot happen against un-verified or red code.

Per the issue, this is the small **additive** half of [IMS#122](https://github.com/FrankRay78/IMS/issues/122) — the orchestrator only. NetPace never built IMS's green-ledger/Stop-hook machinery, so none of the "retire the proxy" scope applies here.

## What changes

- **New `/ship` command** (`.claude/commands/ship.md`) — steps 0–5 with a structural step‑1→step‑2 gate:
  - **0** up-front precondition guard (stop on `main` or no-commits-over-`main` *before* any suite/review; capture a working-tree baseline hash);
  - **1** always run `dotnet build ./src && dotnet test ./src`, gate on **exit code**, red ⇒ STOP;
  - **2** clean-context `pr-review-toolkit` reviewers + `/review-slop`; `/ship`'s own loop turns findings into edits;
  - **3** re-verify + **commit** the fixes, gated on a whole-tracked-tree content-hash diff (not a `*.cs` porcelain filter);
  - **4** raise via `/raise-pr`;
  - **5** `/capture-learnings` on synchronous sources only.
  - Global stop-on-failure.
- **`/capture-learnings`** — adds an unconditional, best-effort per-PR review source (`gh pr view --json comments,reviews`) routed through the existing enforceability triage; a no-op when no PR/review exists, never a wait.
- **`/raise-pr` tidy** — drops the spec-folder confirmation `AskUserQuestion` so the folder is removed and committed without prompting, keeping `/raise-pr` composable by `/ship` with no interactive gate.

## Non-obvious things a reviewer should know

- **Capture-learnings feeds from the *synchronous* in-`/ship` review (Review A), never the async `@claude` PR review (Review B).** `/ship` deliberately does not wait on or prompt about Review B — it's author-gated (`claude.yml`) and posts minutes later for a human to read at merge. This is the core design decision (issue AC-10).
- **No suite-skip for docs-only branches.** The always-on `gh pr create` `PreToolUse` hook re-runs the suite at PR creation anyway, so a skip would save nothing and could let review run before a late hook-block. `/ship` always runs step 1 (AC-5).
- **Change detection uses a content hash of the whole tracked tree**, so it catches build-affecting non-`.cs` edits (`.csproj`, `Directory.Packages.props`, `.json`) and ignores files already dirty before the review — a `*.cs`-only `git status` filter would miss both.
- **No hook polices the step-1→step-2 ordering** and the `gh pr create` hook is unchanged — control flow is the gate, by design.

## How this branch was produced

This PR was **dogfooded through `/ship` itself**: step 1 ran green (616 tests), step 2's `code-reviewer` + slop review surfaced a real control-flow contradiction in the `/capture-learnings` edit (an "unconditional" paragraph nested under a conditionally-skipped step) plus two verbosity trims, `/ship`'s loop applied them, step 3 re-verified green and committed them (`0a80e4e`), and this PR is step 4.

## How to verify

- [ ] Read `ship.md` — confirm the step‑1→step‑2 gate is structural (review is downstream of the exit code) with no ordering hook added.
- [ ] Confirm `/capture-learnings`'s PR-review source is unconditional and clearly *not* skipped when `has_branch_context` is false.
- [ ] Confirm `/raise-pr` no longer prompts to delete the spec folder.
- [ ] `settings.json` and the `gh pr create` hook are untouched; no Constitution amendment.

## Related

- Issue: #223
- Upstream: [IMS#122](https://github.com/FrankRay78/IMS/issues/122); supersedes the async-review seam of [IMS#128](https://github.com/FrankRay78/IMS/pull/128).
