### PR TITLE
Fix raise-pr spec-kit pointer reset to compare repo-relative paths

### DIFF
--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -19,7 +19,7 @@ Read `CLAUDE.md` for project context before proceeding.
 
 4. **Delete spec folder**: Specs are deleted before merge so they don't accumulate on `main`, so remove `<FEATURE_DIR>` and commit the removal without prompting (this keeps `/raise-pr` composable by `/ship` with no interactive gate):
    - Run `git rm -r <FEATURE_DIR>`
-   - Clear the spec-kit feature pointer so it doesn't dangle at a deleted folder on `main`: if `.specify/feature.json` exists and its `feature_directory` points at `<FEATURE_DIR>`, reset it to `{"feature_directory": ""}` and `git add .specify/feature.json`. (A stale pointer makes `check-prerequisites.sh` hard-fail and lets `setup-plan.sh` silently recreate the deleted folder.)
+   - Clear the spec-kit feature pointer so it doesn't dangle at a deleted folder on `main`: if `.specify/feature.json` exists and its `feature_directory` resolves to the same folder as `<FEATURE_DIR>` (compare as repo-relative paths — `FEATURE_DIR` from `--paths-only` is absolute, while the JSON stores a repo-relative path like `specs/NNN-…`), reset it to `{"feature_directory": ""}` and `git add .specify/feature.json`. (A stale pointer makes `check-prerequisites.sh` hard-fail and lets `setup-plan.sh` silently recreate the deleted folder.)
    - Run `git commit -m "chore: remove <FEATURE_DIR>"`
 
 5. **Infer PR title**: Take the branch name from step 1, strip any leading path segment (`feat/`, `fix/`, `chore/`, `docs/`, etc.), strip any leading `NNN-` numeric prefix on the remaining segment, replace hyphens with spaces, and apply title case. Examples: `004-raise-pr-command` → `Raise PR Command`; `chore/speckit-docs-tidy` → `Speckit Docs Tidy`.


### PR DESCRIPTION
## Why

`.claude/commands/raise-pr.md` step 4 clears the spec-kit feature pointer (`.specify/feature.json`) when deleting a branch's spec folder, so it doesn't dangle at a folder that no longer exists on `main`. The reset condition was **unreliable**: it fired only if `feature_directory` "points at `<FEATURE_DIR>`", but `FEATURE_DIR` (from `check-prerequisites.sh --json --paths-only`) is an **absolute** path while `.specify/feature.json` stores a **repo-relative** value (e.g. `specs/004-…`). A literal string comparison never matches, so the pointer can be left dangling — the exact stale-pointer case the bullet exists to prevent (it makes `check-prerequisites.sh` hard-fail and lets `setup-plan.sh` silently recreate the deleted folder).

## What changes

Tightened only that clause to compare as repo-relative paths, with an inline note that `FEATURE_DIR` is absolute while the JSON is repo-relative. The rest of the bullet (hard-fail / recreate rationale) is unchanged.

## Related

Prompt-only change — no code or tests affected.