### PR TITLE
Permission Rule Warnings

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -14,6 +14,7 @@
 - [NetPace CLI feature issues must scope user-facing docs from the start](feedback_cli_feature_doc_scope.md) — first draft must include README --help, USER_GUIDE, design-doc cross-refs (no CHANGELOG — release notes are GitHub-auto-generated)
 - [Release-pipeline changes must update docs/RELEASING.md](feedback_release_pipeline_doc.md) — release matrix, runner-per-RID, naming convention, smoke-test contract live there; out-of-sync = future RID work costs extra
 - [Verify-snapshot tests count as coverage in NetPace.Console.Tests](feedback_console_output_snapshot_coverage.md) — check Expectations/*.verified.txt before reporting an output mode as untested
+- [Speckit file guard is Edit-only by design](speckit_file_guard.md) — one `Edit(path)` deny rule per protected path; `Edit` covers `Write`, so parallel `Write`/`MultiEdit` rules only add startup warnings
 - [Spec-kit upgrade procedure](speckit_upgrade_procedure.md) — stock github/spec-kit via `specify` CLI; `init --here --force --integration claude --script sh` is additive/hash-guarded
 - [feedback_read_source_before_designing.md](feedback_read_source_before_designing.md) — read the source before designing a fix; verify a handed-down issue/spec diagnosis against HEAD before implementing
 - [dotnet test --no-build runs the stale test DLL](feedback_dotnet_test_no_build.md) — rebuild before trusting a test run; green-gate.sh denies a stale --no-build

--- a/.claude/memory/speckit_file_guard.md
+++ b/.claude/memory/speckit_file_guard.md
@@ -8,7 +8,7 @@ type: reference
 
 **One `Edit(path)` rule per path is the whole guard.** File-permission checks consult `Edit(path)` rules only, and an `Edit` rule covers every file-editing tool — `Write` included. A parallel `Write(path)` deny line is accepted but never consulted; `MultiEdit` is a legacy tool name matching no tool at all. Both deny nothing and emit a startup warning apiece. The same applies in `allow`: `Read(**)` covers `Glob`, `Edit(**)` covers `Write`.
 
-**Why:** the guard shipped with `Edit`/`Write`/`MultiEdit` triples on the belief that `Edit` alone left a hole a `Write` could slip through. It didn't — the extra rules produced nine startup warnings and zero extra protection, and were removed 2026-07-30 (matching [FrankRay78/IMS#176](https://github.com/FrankRay78/IMS/pull/176)).
+**Why:** the guard shipped with `Edit`/`Write`/`MultiEdit` triples on the belief that `Edit` alone left a hole a `Write` could slip through. It didn't — those rules plus the equally inert `Glob(**)`/`Write(**)`/`MultiEdit(**)` allow entries produced twelve startup warnings and zero extra protection. Removed 2026-07-30 (#233).
 
 **How to apply:**
 - Adding a protected path: write **one** `Edit(<path>)` deny rule. Don't "strengthen" it with `Write`/`MultiEdit` twins.

--- a/.claude/memory/speckit_file_guard.md
+++ b/.claude/memory/speckit_file_guard.md
@@ -1,0 +1,16 @@
+---
+name: speckit file guard is Edit-only by design
+description: The spec-kit deny rules use one Edit(path) rule per path — an Edit rule covers Write too, so parallel Write/MultiEdit rules only produce startup warnings.
+type: reference
+---
+
+`.claude/settings.json` `permissions.deny` blocks `Edit(<path>)` on the upstream-managed spec-kit files that carry local customizations but are **not** extension points: `.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, `.specify/scripts/bash/*.sh`. `deny` overrides the blanket `Edit(**)` allow and `defaultMode: acceptEdits`, so an agent is stopped at edit-time (rationale: [`docs/change-intent-records/2026-07-10-guard-speckit-files.md`](../../docs/change-intent-records/2026-07-10-guard-speckit-files.md)).
+
+**One `Edit(path)` rule per path is the whole guard.** File-permission checks consult `Edit(path)` rules only, and an `Edit` rule covers every file-editing tool — `Write` included. A parallel `Write(path)` deny line is accepted but never consulted; `MultiEdit` is a legacy tool name matching no tool at all. Both deny nothing and emit a startup warning apiece. The same applies in `allow`: `Read(**)` covers `Glob`, `Edit(**)` covers `Write`.
+
+**Why:** the guard shipped with `Edit`/`Write`/`MultiEdit` triples on the belief that `Edit` alone left a hole a `Write` could slip through. It didn't — the extra rules produced nine startup warnings and zero extra protection, and were removed 2026-07-30 (matching [FrankRay78/IMS#176](https://github.com/FrankRay78/IMS/pull/176)).
+
+**How to apply:**
+- Adding a protected path: write **one** `Edit(<path>)` deny rule. Don't "strengthen" it with `Write`/`MultiEdit` twins.
+- Permission rules only — hook `matcher` fields are a separate mechanism that matches tool names directly and is unaffected by this.
+- A regression is visible at launch: the startup warning names the offending rule.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,12 +2,9 @@
   "permissions": {
     "allow": [
       "Read(**)",
-      "Glob(**)",
       "Grep(**)",
       "LS(**)",
       "Edit(**)",
-      "MultiEdit(**)",
-      "Write(**)",
       "Bash(git status:*)",
       "Bash(git rev-parse:*)",
       "Bash(git log:*)",
@@ -83,14 +80,8 @@
       "Read(**/appsettings.*.json)",
       "Read(**/appsettings.json)",
       "Edit(.claude/skills/speckit-*/SKILL.md)",
-      "Write(.claude/skills/speckit-*/SKILL.md)",
-      "MultiEdit(.claude/skills/speckit-*/SKILL.md)",
       "Edit(.specify/templates/*.md)",
-      "Write(.specify/templates/*.md)",
-      "MultiEdit(.specify/templates/*.md)",
-      "Edit(.specify/scripts/bash/*.sh)",
-      "Write(.specify/scripts/bash/*.sh)",
-      "MultiEdit(.specify/scripts/bash/*.sh)"
+      "Edit(.specify/scripts/bash/*.sh)"
     ],
     "ask": [
       "Bash(rm:*)",

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -50,7 +50,7 @@ The generic enforcement layer, as NetPace wires it. Hooks live in [`.claude/hook
 | Stale-build guard | `green-gate.sh` — denies `dotnet test --no-build` when a `*.cs` under `src/` is newer than the built assembly | PreToolUse(Bash) |
 | No skipped tests | `no-skipped-tests.sh` — blocks commits reintroducing the skip family (incl. xUnit-v3 `SkipUnless=`/`SkipWhen=`); `--check` mode for CI | PreToolUse(Bash) |
 | Traceability gate | `traceability-gate.sh` — spec label ↔ test-plan scenario ↔ `// SCENARIO:` marker under `src/`, exact match; loop-guarded nudge, never a lock-out | Stop |
-| Upstream-file guard | `permissions.deny` (Edit/Write/MultiEdit) on `.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, `.specify/scripts/bash/*.sh` | settings |
+| Upstream-file guard | `permissions.deny` — one `Edit(path)` rule each on `.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, `.specify/scripts/bash/*.sh` (an `Edit` rule covers every file-editing tool, Write included) | settings |
 | Format-on-commit | `dotnet format style/whitespace` on staged `*.cs` (see divergence below) | PreToolUse(Bash), `if git commit` |
 | PR pre-flight | `dotnet build ./src && dotnet test ./src` before `gh pr create` | PreToolUse(Bash), `if gh pr create` |
 | **Test-green gate** | **`/ship` step 1 — a real `dotnet build ./src && dotnet test ./src`. Not a hook.** | — |

--- a/docs/change-intent-records/2026-07-10-guard-speckit-files.md
+++ b/docs/change-intent-records/2026-07-10-guard-speckit-files.md
@@ -3,9 +3,9 @@
 **Intent:** Stop a headless agent (or a stray `specify init --force` regen) from silently mutating the spec-kit files that carry local customizations but are *not* extension points — the failure mode that flipped `disable-model-invocation: true → false` across the SDD skills during the 0.12.10 upgrade.
 
 **Behaviour:**
-- Given: an agent attempts `Edit`/`Write`/`MultiEdit` on a protected file (`.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, or `.specify/scripts/bash/*.sh`)
+- Given: an agent attempts to edit a protected file (`.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, or `.specify/scripts/bash/*.sh`) with any file-editing tool
 - When: the tool call is evaluated against `.claude/settings.json`
-- Then: it is denied, overriding the blanket `Edit(**)`/`Write(**)` allow and `defaultMode: acceptEdits`.
+- Then: it is denied, overriding the blanket `Edit(**)` allow and `defaultMode: acceptEdits`.
 - Given: an agent edits a genuine extension point (`.specify/templates/overrides/**`, `.specify/extensions/**`, `.specify/memory/constitution.md`, `.specify/feature.json`)
 - Then: the edit is allowed — the deny globs do not match these.
 
@@ -18,7 +18,8 @@
 1. **`deny`, not `ask`** — a firmer guarantee against headless drift. Trade-off: a deliberate human edit requires temporarily removing the rule. `ask` (human-approvable, headless-blocked) was rejected as too soft for the stated goal.
 2. **`.claude/settings.json` permissions, not a git pre-commit hook or CI check** — the threat is agent edits, so gate at edit-time via the harness. Rejected: git hook (fires late, needs `core.hooksPath` bootstrap, `--no-verify`-able); CI invariant check (catches upgrade-clobber, a manual one-off, not the agent-drift case).
 3. **`speckit-*` glob over enumerating the manifest's exact 10 skills** — a glob survives new SDD skills (e.g. `speckit-converge`) and can't fail open the way a clever character-class exclusion could. Side effect: also protects the 5 `speckit-git-*` extension skills — a harmless, arguably desirable superset.
+4. **One `Edit(path)` rule per protected path, not parallel `Write`/`MultiEdit` rules** *(amended 2026-07-30)* — file-permission checks consult `Edit(path)` rules only, and an `Edit` rule already covers every file-editing tool. This CIR originally shipped parallel `Write(path)`/`MultiEdit(path)` deny lines on the belief that `Edit` alone left a hole; they denied nothing and emitted a startup warning apiece, so they were removed. The guard is unchanged in strength. Do not re-add them.
 
-**Known residual:** the guard covers the `Edit`/`Write`/`MultiEdit` tool path only; a `sed -i`/`git checkout` via `Bash` can still overwrite these files. Out of scope here — a manifest-vs-deny-glob CI check would be the backstop if durable protection is ever needed.
+**Known residual:** the guard covers the file-editing tool path only; a `sed -i`/`git checkout` via `Bash` can still overwrite these files. Out of scope here — a manifest-vs-deny-glob CI check would be the backstop if durable protection is ever needed.
 
 **Date:** 2026-07-10


### PR DESCRIPTION
## Why

Every session opened with twelve permission warnings:

```
Permission deny rule "MultiEdit(.specify/templates/*.md)" matches no known tool — check for typos.
Permission allow rule (.claude/settings.json): Write(**) is not matched by file permission checks —
only Edit(path) rules are. Use Edit(**) instead (Edit rules cover all file-editing tools).
```

File-permission checks consult `Edit(path)` rules only, and an `Edit` rule covers **every** file-editing tool — Write included. `MultiEdit` is a legacy tool name that matches nothing at all. So the parallel `Write(...)`/`MultiEdit(...)` deny rules added alongside each guarded spec-kit path in #215 denied nothing, and the `Glob(**)`/`MultiEdit(**)`/`Write(**)` allow entries allowed nothing already covered by `Read(**)`/`Edit(**)`. Twelve inert lines, twelve warnings.

## What changes

- `settings.json` `deny` — back to one `Edit(path)` rule per guarded spec-kit path. The guard is unchanged in strength.
- `settings.json` `allow` — dropped the three inert entries.
- The two docs that described the guard as covering "Edit/Write/MultiEdit" now describe it accurately, and the CIR carries a dated Decision 4 recording that the parallel rules denied nothing and must not be re-added.
- New memory entry `speckit_file_guard.md` — NetPace had none, so nothing was stopping this being "strengthened" a third time.

## Non-obvious things a reviewer should know

Permission rules and hook `matcher` fields are different mechanisms. A hook matcher matches tool names directly, so a `Write`/`MultiEdit` arm in a `"matcher"` string is a separate question from the above — NetPace's only hook matcher is `Bash`, so nothing here touches hooks, and the memory entry says so explicitly to stop a future reader over-applying the rule.

## How to verify

- [ ] Start a session on this branch — the twelve warnings are gone.
- [ ] Ask an agent to `Write` to a path under `.specify/templates/` — still denied with only the `Edit(...)` rule present. (Verified during authoring: a `Write` to `.specify/templates/deny-probe.md` was blocked.)
- [ ] Confirm a genuine extension point (`.specify/templates/overrides/**`, `.specify/memory/constitution.md`) is still editable.

## Related

- Amends #215 (Guard Speckit Files).
