### PR TITLE
Move formatting to ship cadence

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -27,7 +27,7 @@ Read `CLAUDE.md` for project context before proceeding.
    dotnet format style ./src/NetPace.sln && dotnet format whitespace ./src/NetPace.sln
    ```
 
-   The explicit `./src/NetPace.sln` argument is **required, not decorative**: `dotnet format` looks for a project or solution in the *current directory only*, and NetPace's solution is at `src/`, not the repo root. Omitting it fails with `Could not find a MSBuild project file or solution file` — which is exactly how the retired format-on-commit hook silently no-op'd for four months (#234).
+   The explicit `./src/NetPace.sln` argument is **required, not decorative**: `dotnet format` looks for a project or solution in the *current directory only*, and NetPace's solution is at `src/`, not the repo root. Omitting it fails with `Could not find a MSBuild project file or solution file`.
 
    - Formatting runs **once per ship**, not per commit. It is cosmetic work at a cadence that already costs minutes — see *Formatting is not verification* in [agentic-workflow.md](../../docs/agentic-workflow.md).
    - **If formatting changed files, commit them now** — `git add -A` and a `style: apply dotnet format` message — *before* running the suite. This restores the clean working tree step 0 established, which is what keeps step 3's "anything in the tree is a review edit" invariant true. Do not carry format edits forward into the review commit; they are a separate concern and belong in their own commit.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -4,7 +4,7 @@ description: Orchestrator that turns "implementation looks done" into a reviewed
 
 Read `CLAUDE.md` for project context before proceeding.
 
-`/ship` composes NetPace's existing commands behind one hard gate: **the full test suite runs first, and nothing downstream happens unless it is green.** The gate is structural — the review step is downstream of the step-1 exit code, so it cannot begin against un-verified or red code. Do not add a hook to police this ordering; the exit code *is* the gate.
+`/ship` composes NetPace's existing commands behind one hard gate: **the full test suite gates everything downstream, and no review or PR happens unless it is green.** The gate is structural — the review step is downstream of the step-1 exit code, so it cannot begin against un-verified or red code. Do not add a hook to police this ordering; the exit code *is* the gate. The one step that precedes the suite is formatting (step 1a), which is cosmetic and is itself covered by the gate that follows it.
 
 `/ship` is designed to run to completion **without prompting**, so it can be driven by an automated loop (e.g. shipping many features back-to-back) as well as invoked directly. Reflection (`/capture-learnings`) is deliberately **not** a step: it needs human curation and batches better across many features, so it belongs at a supervised checkpoint after a batch — not inside each ship, where it would either block the loop or be auto-skipped to nothing. `/ship` likewise never waits on the async `@claude` PR review (see below).
 
@@ -19,7 +19,22 @@ Read `CLAUDE.md` for project context before proceeding.
 
    The precondition guard runs up front deliberately: `/raise-pr`'s own late branch check must not be the first line of defence, or the full suite and full review would run pointlessly first.
 
-1. **Full test run (always).** Run `dotnet build ./src && dotnet test ./src` — always, including docs-only branches. Do not add a skip path for docs-only branches: the suite is fast, and the always-on `gh pr create` `PreToolUse` hook re-runs it at step 4 anyway, so a skip saves nothing and could let review run before a late hook-block.
+1. **Format (1a), then the full test run (1b).**
+
+   **1a — Format the tree.** Run:
+
+   ```bash
+   dotnet format style ./src/NetPace.sln && dotnet format whitespace ./src/NetPace.sln
+   ```
+
+   The explicit `./src/NetPace.sln` argument is **required, not decorative**: `dotnet format` looks for a project or solution in the *current directory only*, and NetPace's solution is at `src/`, not the repo root. Omitting it fails with `Could not find a MSBuild project file or solution file` — which is exactly how the retired format-on-commit hook silently no-op'd for four months (#234).
+
+   - Formatting runs **once per ship**, not per commit. It is cosmetic work at a cadence that already costs minutes — see *Formatting is not verification* in [agentic-workflow.md](../../docs/agentic-workflow.md).
+   - **If formatting changed files, commit them now** — `git add -A` and a `style: apply dotnet format` message — *before* running the suite. This restores the clean working tree step 0 established, which is what keeps step 3's "anything in the tree is a review edit" invariant true. Do not carry format edits forward into the review commit; they are a separate concern and belong in their own commit.
+   - A **non-zero exit** from `dotnet format` is a real failure (bad workspace argument, unparseable source) ⇒ **STOP and report**. A clean run that merely rewrote files is not a failure.
+   - Formatting deliberately precedes 1b so that any change it makes is verified by the suite below, rather than landing after the gate has already passed.
+
+   **1b — Full test run (always).** Run `dotnet build ./src && dotnet test ./src` — always, including docs-only branches. Do not add a skip path for docs-only branches: the suite is fast, and the always-on `gh pr create` `PreToolUse` hook re-runs it at step 4 anyway, so a skip saves nothing and could let review run before a late hook-block.
    - Gate on the run's **exit code**, not on any stored marker.
    - **Not green ⇒ STOP:** report the failures to the invoker and do nothing else — no review subagents, no PR.
    - **Green ⇒ continue.**
@@ -51,4 +66,4 @@ Read `CLAUDE.md` for project context before proceeding.
 
 ## Final report
 
-Report to the invoker: the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge.
+Report to the invoker: whether formatting changed anything (and the commit if it did), the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,12 +113,6 @@
           },
           {
             "type": "command",
-            "command": "STAGED=$(git diff --cached --name-only | grep \"[.]cs$\"); [ -z \"$STAGED\" ] && exit 0; INCLUDE=$(echo \"$STAGED\" | tr '\\n' ' '); dotnet format style --include $INCLUDE && dotnet format whitespace --include $INCLUDE && echo \"$STAGED\" | xargs -d '\\n' git add",
-            "if": "Bash(git commit:*)",
-            "statusMessage": "Formatting staged .cs files..."
-          },
-          {
-            "type": "command",
             "command": "dotnet build ./src && dotnet test ./src",
             "if": "Bash(gh pr create:*)",
             "statusMessage": "Running build and tests before PR creation..."

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 *.verified.json text eol=lf working-tree-encoding=UTF-8
 
 *.sh text eol=lf
+
+*.cs text eol=lf

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -53,24 +53,27 @@ The generic enforcement layer, as NetPace wires it. Hooks live in [`.claude/hook
 | Upstream-file guard | `permissions.deny` — one `Edit(path)` rule each on `.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, `.specify/scripts/bash/*.sh` (an `Edit` rule covers every file-editing tool, Write included) | settings |
 | PR pre-flight | `dotnet build ./src && dotnet test ./src` before `gh pr create` | PreToolUse(Bash), `if gh pr create` |
 | **Formatting** | **`/ship` step 1a — `dotnet format style/whitespace ./src/NetPace.sln`, once per PR. Not a hook** (see below) | — |
-| **Test-green gate** | **`/ship` step 1 — a real `dotnet build ./src && dotnet test ./src`. Not a hook.** | — |
+| **Test-green gate** | **`/ship` step 1b — a real `dotnet build ./src && dotnet test ./src`. Not a hook.** | — |
 
 Every hook is **fail-open with an announced override** (`NETPACE_SKIP_GREEN_GATE=1`, `NETPACE_ALLOW_SKIPS=1`, `NETPACE_SKIP_TRACEABILITY_GATE=1`). For a harness edited with itself, a false block can lock out the tools that would fix it — so uncertain paths allow, and the override announces itself on stderr.
 
+Every hook is also a **script in `.claude/hooks/` with a `.tests.sh` case matrix beside it**, never an inline one-liner in `settings.json`. An untested gate can no-op silently — a bad path or a missing argument makes it exit without doing its job — and from the outside that is indistinguishable from a gate that passed. Note too that only **exit 2** blocks a `PreToolUse` hook; any other non-zero exit is reported and ignored, so a gate that means to block must say so explicitly.
+
 **Two generic gates do not apply here.** NetPace has **no stack-guard** — there is no external service stack to orchestrate — and **no UI-automation denylist**: it is a console CLI, not a browser UI, so a denylist has nothing to guard. NetPace's console output *is* verified — see below — just not by a browser-automation framework.
 
-### Formatting — reconciled to ship cadence (no divergence)
+### Formatting
 
-NetPace **used to** format on commit, via a `PreToolUse(Bash)` hook on `git commit`. That hook is gone; formatting now runs once per PR as `/ship` step 1a, exactly as the generic guide's *Formatting is not verification — do it at ship cadence* section prescribes. **No divergence remains.** Settled in #234; measurements that decided it:
+Formatting runs **once per PR**, as `/ship` step 1a — never on commit. This is the generic guide's *Formatting is not verification — do it at ship cadence* section, made concrete:
 
-- **The per-commit cost was real.** Timed against `src/NetPace.sln` (84 `.cs` files, ~9,900 LOC): 21.4s for a single staged file, 29.5s for a seven-file branch set. The cost is MSBuild **workspace load**, not file count, so staging fewer files does not help. The guide's "tens of seconds" holds even on a solution this small — the obvious counter-argument for keeping per-commit did not survive contact with a stopwatch.
-- **The value was near zero.** The hook had in fact been a **no-op since it was added** — it invoked `dotnet format` with no workspace argument, and `dotnet format` searches only the current directory, where NetPace has no `.sln`. Every invocation died with `Could not find a MSBuild project file or solution file` and exit 1, which is a non-blocking `PreToolUse` result, so commits sailed through unformatted for four and a half months. The accumulated drift over that window: **three** import-ordering findings and **223** whitespace fixes, nearly all of them trailing spaces on otherwise-blank lines. Nothing a reviewer would have caught.
+```bash
+dotnet format style ./src/NetPace.sln && dotnet format whitespace ./src/NetPace.sln
+```
 
-**The transferable lesson is about gates, not formatting.** Every other gate in the table above is a script in `.claude/hooks/` with a `.tests.sh` case matrix beside it, and every one of them works. The format hook was the only **inline one-liner in `settings.json`** — untested, and the only one that silently rotted. *A gate that is not itself tested is not a gate.*
+The explicit solution argument is **required, not decorative**: `dotnet format` looks for a project or solution in the *current directory only*, and NetPace's lives under `src/`, not the repo root. Omitting it fails outright.
 
-**Line endings, settled alongside.** `.editorconfig` sets `end_of_line = lf` and the index stores LF, but `.gitattributes` used to pin `eol=lf` only for `*.sh` and `*.verified.*`. On a Windows checkout with `core.autocrlf=true` that left the working tree CRLF, so `dotnet format whitespace` rewrote every file it touched — no committed diff (the rewrite normalises back to LF on commit) but wasted work on every ship run from Windows, and ~9,900 phantom findings drowning the 223 real ones. `.gitattributes` now carries **`*.cs text eol=lf`**, which makes checkout LF on every platform and no longer depends on each developer's `core.autocrlf`. It was a zero-diff change — the index was already LF — so no renormalisation commit was needed.
+**Why not per-commit.** Measured on this solution (84 `.cs` files, ~9,900 LOC): **21.4s** for a single staged file, **29.5s** for a seven-file set. The cost is MSBuild **workspace load**, not file count — so staging fewer files makes it no cheaper, and every commit would pay the full ~20–30s. Against that, a release cycle's worth of drift is a handful of import reorderings and a couple of hundred trailing spaces on blank lines: nothing a reviewer would catch. The guide's "tens of seconds" figure holds even at this size, which is why the "our solution is small enough to absorb it" argument does not survive.
 
-Windows working trees created *before* that line need a one-time refresh to pick the attribute up (re-clone, or `git rm --cached -r . && git reset --hard` on a clean tree). Fresh clones and Linux checkouts are unaffected.
+**Line endings.** `.gitattributes` pins `*.cs text eol=lf`, agreeing with `.editorconfig`'s `end_of_line = lf` and the LF the index already stores. Without it, a Windows checkout with `core.autocrlf=true` gets a CRLF working tree, and `dotnet format whitespace` then rewrites every file it touches — no committed diff, since the rewrite normalises back on commit, but thousands of phantom findings drowning the real ones. A Windows working tree created *before* that attribute needs a one-time refresh to pick it up (re-clone, or `git rm --cached -r . && git reset --hard` on a clean tree); fresh clones and Linux checkouts are unaffected.
 
 ## `/ship`
 

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -51,23 +51,33 @@ The generic enforcement layer, as NetPace wires it. Hooks live in [`.claude/hook
 | No skipped tests | `no-skipped-tests.sh` — blocks commits reintroducing the skip family (incl. xUnit-v3 `SkipUnless=`/`SkipWhen=`); `--check` mode for CI | PreToolUse(Bash) |
 | Traceability gate | `traceability-gate.sh` — spec label ↔ test-plan scenario ↔ `// SCENARIO:` marker under `src/`, exact match; loop-guarded nudge, never a lock-out | Stop |
 | Upstream-file guard | `permissions.deny` — one `Edit(path)` rule each on `.claude/skills/speckit-*/SKILL.md`, `.specify/templates/*.md`, `.specify/scripts/bash/*.sh` (an `Edit` rule covers every file-editing tool, Write included) | settings |
-| Format-on-commit | `dotnet format style/whitespace` on staged `*.cs` (see divergence below) | PreToolUse(Bash), `if git commit` |
 | PR pre-flight | `dotnet build ./src && dotnet test ./src` before `gh pr create` | PreToolUse(Bash), `if gh pr create` |
+| **Formatting** | **`/ship` step 1a — `dotnet format style/whitespace ./src/NetPace.sln`, once per PR. Not a hook** (see below) | — |
 | **Test-green gate** | **`/ship` step 1 — a real `dotnet build ./src && dotnet test ./src`. Not a hook.** | — |
 
 Every hook is **fail-open with an announced override** (`NETPACE_SKIP_GREEN_GATE=1`, `NETPACE_ALLOW_SKIPS=1`, `NETPACE_SKIP_TRACEABILITY_GATE=1`). For a harness edited with itself, a false block can lock out the tools that would fix it — so uncertain paths allow, and the override announces itself on stderr.
 
 **Two generic gates do not apply here.** NetPace has **no stack-guard** — there is no external service stack to orchestrate — and **no UI-automation denylist**: it is a console CLI, not a browser UI, so a denylist has nothing to guard. NetPace's console output *is* verified — see below — just not by a browser-automation framework.
 
-### Divergence to reconcile — format-on-commit
+### Formatting — reconciled to ship cadence (no divergence)
 
-NetPace formats on commit (the `dotnet format` hook above). The generic guide's *Formatting is not verification — do it at ship cadence* section argues the opposite: per-commit formatting taxes every commit to fix something no reviewer would catch, and the step belongs in `/ship`. This is an **unreconciled divergence** — either move formatting into the ship flow, or record here why per-commit is deliberately kept. Flagged, not silently retained.
+NetPace **used to** format on commit, via a `PreToolUse(Bash)` hook on `git commit`. That hook is gone; formatting now runs once per PR as `/ship` step 1a, exactly as the generic guide's *Formatting is not verification — do it at ship cadence* section prescribes. **No divergence remains.** Settled in #234; measurements that decided it:
+
+- **The per-commit cost was real.** Timed against `src/NetPace.sln` (84 `.cs` files, ~9,900 LOC): 21.4s for a single staged file, 29.5s for a seven-file branch set. The cost is MSBuild **workspace load**, not file count, so staging fewer files does not help. The guide's "tens of seconds" holds even on a solution this small — the obvious counter-argument for keeping per-commit did not survive contact with a stopwatch.
+- **The value was near zero.** The hook had in fact been a **no-op since it was added** — it invoked `dotnet format` with no workspace argument, and `dotnet format` searches only the current directory, where NetPace has no `.sln`. Every invocation died with `Could not find a MSBuild project file or solution file` and exit 1, which is a non-blocking `PreToolUse` result, so commits sailed through unformatted for four and a half months. The accumulated drift over that window: **three** import-ordering findings and **223** whitespace fixes, nearly all of them trailing spaces on otherwise-blank lines. Nothing a reviewer would have caught.
+
+**The transferable lesson is about gates, not formatting.** Every other gate in the table above is a script in `.claude/hooks/` with a `.tests.sh` case matrix beside it, and every one of them works. The format hook was the only **inline one-liner in `settings.json`** — untested, and the only one that silently rotted. *A gate that is not itself tested is not a gate.*
+
+**Line endings, settled alongside.** `.editorconfig` sets `end_of_line = lf` and the index stores LF, but `.gitattributes` used to pin `eol=lf` only for `*.sh` and `*.verified.*`. On a Windows checkout with `core.autocrlf=true` that left the working tree CRLF, so `dotnet format whitespace` rewrote every file it touched — no committed diff (the rewrite normalises back to LF on commit) but wasted work on every ship run from Windows, and ~9,900 phantom findings drowning the 223 real ones. `.gitattributes` now carries **`*.cs text eol=lf`**, which makes checkout LF on every platform and no longer depends on each developer's `core.autocrlf`. It was a zero-diff change — the index was already LF — so no renormalisation commit was needed.
+
+Windows working trees created *before* that line need a one-time refresh to pick the attribute up (re-clone, or `git rm --cached -r . && git reset --hard` on a clean tree). Fresh clones and Linux checkouts are unaffected.
 
 ## `/ship`
 
 NetPace's `/ship` follows the generic *ship gate* section as written:
 
-- **Always runs the suite.** Step 1 is `dotnet build ./src && dotnet test ./src` — no docs-only skip. The suite is fast (no external stack), and the `gh pr create` pre-flight hook would re-run it anyway, so a skip would save nothing.
+- **Formats first.** Step 1a runs `dotnet format style/whitespace ./src/NetPace.sln` and commits any result on its own, before the suite — so formatting is verified by the gate rather than landing after it, and step 3's clean-tree invariant survives. The explicit solution argument is load-bearing (see above).
+- **Always runs the suite.** Step 1b is `dotnet build ./src && dotnet test ./src` — no docs-only skip. The suite is fast (no external stack), and the `gh pr create` pre-flight hook would re-run it anyway, so a skip would save nothing.
 - **Review B posts.** Because `claude.yml` is wired, the async `@claude` review the generic flow describes actually appears on the PR. `/ship` still never waits on it.
 
 ## Test-green gate & categories


### PR DESCRIPTION
Closes #234.

## Why

`docs/agentic-workflow.md` argues formatting does not belong on the inner loop — it should run once per PR, at a cadence that already costs minutes. NetPace did the opposite via a `PreToolUse(Bash)` hook on `git commit`, and the delta doc flagged that as an **unreconciled divergence**. This settles it in the guide's favour, on evidence.

Two measurements decided it:

- **The per-commit cost was real.** Timed against `src/NetPace.sln`: **21.4s** for a single staged file, **29.5s** for a seven-file set. The cost is MSBuild *workspace load*, not file count, so staging fewer files does not help. The guide's "tens of seconds" holds even on a solution this small — which was the main argument for keeping per-commit.
- **The value was near zero.** The hook had in fact been a **no-op since #162**. It invoked `dotnet format` with no workspace argument, and `dotnet format` searches only the current directory — where NetPace has no `.sln`. Every invocation died with `Could not find a MSBuild project file or solution file` and exit 1, a *non-blocking* `PreToolUse` result, so commits went through unformatted for four and a half months. Total drift over that window: **3** import-ordering findings and **223** trailing-whitespace fixes.

## What changes

- **The format hook is deleted.** The other three hooks are untouched.
- **`/ship` step 1 splits into 1a (format) and 1b (full test run).** Step 1a runs `dotnet format style/whitespace ./src/NetPace.sln` and commits any result on its own *before* the suite.
- **`*.cs text eol=lf`** added to `.gitattributes` (separate commit).
- **The delta doc's "Divergence to reconcile" section becomes a settled position**, and the gates table moves formatting from a hook to a `/ship` step.

## Non-obvious things a reviewer should know

- **The `./src/NetPace.sln` argument in step 1a is load-bearing, not decorative.** Omitting it is precisely the bug that made the old hook a silent no-op. Please don't "tidy" it away.
- **Step 1a commits its own changes before the suite runs.** That is deliberate: step 0 requires a clean tree so that step 3 can assume "anything in the tree after review is a review edit". Formatting must restore that invariant rather than leaving edits for the review commit to sweep up.
- **The `.gitattributes` change is zero-diff.** The index was already LF; only Windows working trees were CRLF, via `core.autocrlf=true`. No renormalisation commit is needed. Windows trees created before this line need a one-time refresh to pick the attribute up.
- **No source files are touched by this PR.** The first `/ship` run on any branch will produce a one-off repo-wide `style: apply dotnet format` commit (the 3 + 223 findings above). That is expected, and is better done deliberately on its own branch than folded in here.
- **IMS is deliberately not synced.** The two `ship.md` files are otherwise the same document with per-repo slot substitutions, so this does open a divergence in it. IMS is code-complete; the delta doc records how step 1a ports when it next takes a version (behind IMS's existing source-root probe, plus `gofmt` for chaincode).

## How to verify

- [ ] `dotnet format style ./src/NetPace.sln --verify-no-changes` reports the 3 import-ordering findings — i.e. the command in step 1a actually resolves a workspace, unlike the deleted hook.
- [ ] Running the same command *without* the `./src/NetPace.sln` argument from the repo root reproduces the original `Could not find a MSBuild project file or solution file` failure.
- [ ] `git ls-files --eol src/NetPace.Core/SpeedScale.cs` shows `attr/text eol=lf`, and `git status` shows no source files modified.
- [ ] `git commit` no longer triggers a "Formatting staged .cs files..." hook.

## Related

- #234 — the reconciliation issue, including the full investigation and measurements.
- #232 — added the guide section this reconciles against.
- #162 — introduced the hook.