### PR TITLE
Profile XmlDoc File Sharing

### DIFF
--- a/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
+++ b/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
@@ -1,4 +1,3 @@
-using System.Xml;
 using System.Xml.Linq;
 using Shouldly;
 
@@ -7,13 +6,10 @@ namespace NetPace.Core.Tests;
 /// <summary>
 /// Verifies <see cref="Profile.Mega"/>'s XML documentation includes the undocumented-payload
 /// caveat, so the warning ships to NuGet consumers via NetPace.Core.xml, and that the loader
-/// used to read that file tolerates a build concurrently rewriting it.
+/// used to read that file tolerates a concurrent writer.
 /// </summary>
 public sealed class ProfileXmlDocTests
 {
-    private const int LoadAttempts = 5;
-    private const int LoadRetryDelayMs = 50;
-
     [Fact]
     public void Profile_Mega_XmlDoc_DocumentsBonusPayloadDependency()
     {
@@ -43,21 +39,16 @@ public sealed class ProfileXmlDocTests
     {
         // SCENARIO: XML doc loads while a concurrent writer holds the file
         //
-        // Regression (Principle IX mechanism-pinning exception). NetPace.Core.xml is a build-copied
-        // artefact sitting in this test project's own output directory, so a build that overlaps the
-        // test run can hold it open for writing. XDocument.Load(string) opens with FileShare.Read —
-        // a share mode that refuses to coexist with an existing writer — so the open failed with
-        // "The process cannot access the file because it is being used by another process", failing
-        // the suite intermittently.
-        //
-        // Only Windows enforces share modes, so only there can this test tell the old load from the
-        // new one; that is why the premise is asserted under OperatingSystem.IsWindows() rather than
-        // assumed. The outcome is asserted on every platform and nothing is skipped (Principle X),
-        // but a Unix-only CI run cannot catch a revert of LoadXmlDoc.
+        // Regression: NetPace.Core.xml is a build-copied artefact in this test project's own output
+        // directory, so a build overlapping the test run can hold it open for writing.
+        // XDocument.Load(string) opens with FileShare.Read, a share mode that refuses to coexist
+        // with an existing writer, so the read failed intermittently with "The process cannot
+        // access the file because it is being used by another process". Only Windows enforces share
+        // modes, so the premise is asserted there rather than assumed — on Unix this test still runs
+        // and still asserts the outcome, but cannot catch a revert of LoadXmlDoc.
 
         // Given
-        // A private temp file, so the test never contends for the real build artefact — the
-        // file-sharing behaviour under test is identical on any path.
+        // A private temp file, so the test never contends for the real build artefact.
         var xmlPath = Path.Join(Path.GetTempPath(), $"netpace-xmldoc-share-{Guid.NewGuid()}.xml");
         File.WriteAllText(xmlPath, "<doc><members /></doc>");
 
@@ -67,7 +58,6 @@ public sealed class ProfileXmlDocTests
 
             if (OperatingSystem.IsWindows())
             {
-                // If this ever stops throwing, the assertion below has quietly stopped proving anything.
                 Should.Throw<IOException>(() => XDocument.Load(xmlPath));
             }
 
@@ -79,14 +69,10 @@ public sealed class ProfileXmlDocTests
         }
         finally
         {
-            TryDelete(xmlPath);
+            File.Delete(xmlPath);
         }
     }
 
-    /// <summary>
-    /// Resolves NetPace.Core.xml, copied next to the referenced NetPace.Core assembly by the
-    /// project reference.
-    /// </summary>
     private static string ResolveCoreXmlDocPath()
     {
         var assemblyPath = typeof(Profile).Assembly.Location;
@@ -97,43 +83,12 @@ public sealed class ProfileXmlDocTests
     }
 
     /// <summary>
-    /// Loads the XML doc, tolerating a build that is concurrently rewriting it. Two transient
-    /// conditions are possible: the open is refused because a writer holds the file, or the file is
-    /// observed part-written and fails to parse. Both are retried; a persistent failure still throws.
+    /// Opens with <see cref="FileShare.ReadWrite"/> so a concurrent writer cannot fail the read;
+    /// <c>XDocument.Load(string)</c> opens with <see cref="FileShare.Read"/> and throws instead.
     /// </summary>
     private static XDocument LoadXmlDoc(string xmlPath)
     {
-        for (var attempt = 1; ; attempt++)
-        {
-            try
-            {
-                using var stream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                return XDocument.Load(stream);
-            }
-            catch (IOException) when (attempt < LoadAttempts)
-            {
-                Thread.Sleep(LoadRetryDelayMs);
-            }
-            catch (XmlException) when (attempt < LoadAttempts)
-            {
-                Thread.Sleep(LoadRetryDelayMs);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Deletes the temp file, guarding only the delete so a cleanup failure cannot replace a real
-    /// assertion failure propagating out of the test.
-    /// </summary>
-    private static void TryDelete(string path)
-    {
-        try
-        {
-            File.Delete(path);
-        }
-        catch (IOException)
-        {
-            // A transient lock on the temp file is not worth failing the test over.
-        }
+        using var stream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        return XDocument.Load(stream);
     }
 }

--- a/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
+++ b/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
@@ -15,13 +15,10 @@ public sealed class ProfileXmlDocTests
         // SCENARIO: Mega's bonus-payload dependency is documented
 
         // Given
-        var assemblyPath = typeof(Profile).Assembly.Location;
-        var xmlPath = Path.ChangeExtension(assemblyPath, ".xml");
-        File.Exists(xmlPath).ShouldBeTrue(
-            $"Expected NetPace.Core.xml next to assembly at '{xmlPath}'. Ensure <GenerateDocumentationFile>true</GenerateDocumentationFile> is set on NetPace.Core.csproj.");
+        var xmlPath = ResolveCoreXmlDocPath();
 
         // When
-        var doc = XDocument.Load(xmlPath);
+        var doc = LoadXmlDoc(xmlPath);
         var memberNode = doc.Descendants("member")
             .FirstOrDefault(m => (string?)m.Attribute("name") == "F:NetPace.Core.Profile.Mega");
 
@@ -34,5 +31,57 @@ public sealed class ProfileXmlDocTests
         summary.ShouldContain("6000");
         summary.ShouldContain("7000");
         summary.ShouldContain("download-upload-size-controls");
+    }
+
+    [Fact]
+    public void LoadXmlDoc_WhenAnotherProcessHoldsTheFileOpenForWriting_StillLoadsTheDocument()
+    {
+        // SCENARIO: XML doc loads while a concurrent writer holds the file
+        // Regression: a solution-level `dotnet test ./src` copies NetPace.Core.xml into both test
+        // projects' output directories, so the file can be held open for writing when this suite
+        // runs. XDocument.Load(string) opens with FileShare.Read, which denies that writer and
+        // throws IOException, failing the suite intermittently.
+
+        // Given
+        // A private temp file, so the test never contends for the real build artefact — the
+        // file-sharing behaviour under test is identical either way.
+        var xmlPath = Path.Join(Path.GetTempPath(), $"netpace-xmldoc-share-{Guid.NewGuid()}.xml");
+        File.WriteAllText(xmlPath, "<doc><members /></doc>");
+        try
+        {
+            using var competingWriter = new FileStream(xmlPath, FileMode.Open, FileAccess.Write, FileShare.Read);
+
+            // When
+            var doc = LoadXmlDoc(xmlPath);
+
+            // Then
+            doc.Root!.Name.LocalName.ShouldBe("doc");
+        }
+        finally
+        {
+            File.Delete(xmlPath);
+        }
+    }
+
+    /// <summary>
+    /// Resolves NetPace.Core.xml, which MSBuild emits alongside the loaded NetPace.Core assembly.
+    /// </summary>
+    private static string ResolveCoreXmlDocPath()
+    {
+        var assemblyPath = typeof(Profile).Assembly.Location;
+        var xmlPath = Path.ChangeExtension(assemblyPath, ".xml");
+        File.Exists(xmlPath).ShouldBeTrue(
+            $"Expected NetPace.Core.xml next to assembly at '{xmlPath}'. Ensure <GenerateDocumentationFile>true</GenerateDocumentationFile> is set on NetPace.Core.csproj.");
+        return xmlPath;
+    }
+
+    /// <summary>
+    /// Loads the XML doc tolerating a concurrent writer. <c>XDocument.Load(string)</c> opens with
+    /// <see cref="FileShare.Read"/>, which denies any process holding the file open for writing.
+    /// </summary>
+    private static XDocument LoadXmlDoc(string xmlPath)
+    {
+        using var stream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        return XDocument.Load(stream);
     }
 }

--- a/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
+++ b/src/NetPace.Core.Tests/ProfileXmlDocTests.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using System.Xml.Linq;
 using Shouldly;
 
@@ -5,10 +6,14 @@ namespace NetPace.Core.Tests;
 
 /// <summary>
 /// Verifies <see cref="Profile.Mega"/>'s XML documentation includes the undocumented-payload
-/// caveat, so the warning ships to NuGet consumers via NetPace.Core.xml.
+/// caveat, so the warning ships to NuGet consumers via NetPace.Core.xml, and that the loader
+/// used to read that file tolerates a build concurrently rewriting it.
 /// </summary>
 public sealed class ProfileXmlDocTests
 {
+    private const int LoadAttempts = 5;
+    private const int LoadRetryDelayMs = 50;
+
     [Fact]
     public void Profile_Mega_XmlDoc_DocumentsBonusPayloadDependency()
     {
@@ -34,22 +39,37 @@ public sealed class ProfileXmlDocTests
     }
 
     [Fact]
-    public void LoadXmlDoc_WhenAnotherProcessHoldsTheFileOpenForWriting_StillLoadsTheDocument()
+    public void LoadXmlDoc_WhileAConcurrentWriterHoldsTheFile_StillLoadsTheDocument()
     {
         // SCENARIO: XML doc loads while a concurrent writer holds the file
-        // Regression: a solution-level `dotnet test ./src` copies NetPace.Core.xml into both test
-        // projects' output directories, so the file can be held open for writing when this suite
-        // runs. XDocument.Load(string) opens with FileShare.Read, which denies that writer and
-        // throws IOException, failing the suite intermittently.
+        //
+        // Regression (Principle IX mechanism-pinning exception). NetPace.Core.xml is a build-copied
+        // artefact sitting in this test project's own output directory, so a build that overlaps the
+        // test run can hold it open for writing. XDocument.Load(string) opens with FileShare.Read —
+        // a share mode that refuses to coexist with an existing writer — so the open failed with
+        // "The process cannot access the file because it is being used by another process", failing
+        // the suite intermittently.
+        //
+        // Only Windows enforces share modes, so only there can this test tell the old load from the
+        // new one; that is why the premise is asserted under OperatingSystem.IsWindows() rather than
+        // assumed. The outcome is asserted on every platform and nothing is skipped (Principle X),
+        // but a Unix-only CI run cannot catch a revert of LoadXmlDoc.
 
         // Given
         // A private temp file, so the test never contends for the real build artefact — the
-        // file-sharing behaviour under test is identical either way.
+        // file-sharing behaviour under test is identical on any path.
         var xmlPath = Path.Join(Path.GetTempPath(), $"netpace-xmldoc-share-{Guid.NewGuid()}.xml");
         File.WriteAllText(xmlPath, "<doc><members /></doc>");
+
         try
         {
             using var competingWriter = new FileStream(xmlPath, FileMode.Open, FileAccess.Write, FileShare.Read);
+
+            if (OperatingSystem.IsWindows())
+            {
+                // If this ever stops throwing, the assertion below has quietly stopped proving anything.
+                Should.Throw<IOException>(() => XDocument.Load(xmlPath));
+            }
 
             // When
             var doc = LoadXmlDoc(xmlPath);
@@ -59,12 +79,13 @@ public sealed class ProfileXmlDocTests
         }
         finally
         {
-            File.Delete(xmlPath);
+            TryDelete(xmlPath);
         }
     }
 
     /// <summary>
-    /// Resolves NetPace.Core.xml, which MSBuild emits alongside the loaded NetPace.Core assembly.
+    /// Resolves NetPace.Core.xml, copied next to the referenced NetPace.Core assembly by the
+    /// project reference.
     /// </summary>
     private static string ResolveCoreXmlDocPath()
     {
@@ -76,12 +97,43 @@ public sealed class ProfileXmlDocTests
     }
 
     /// <summary>
-    /// Loads the XML doc tolerating a concurrent writer. <c>XDocument.Load(string)</c> opens with
-    /// <see cref="FileShare.Read"/>, which denies any process holding the file open for writing.
+    /// Loads the XML doc, tolerating a build that is concurrently rewriting it. Two transient
+    /// conditions are possible: the open is refused because a writer holds the file, or the file is
+    /// observed part-written and fails to parse. Both are retried; a persistent failure still throws.
     /// </summary>
     private static XDocument LoadXmlDoc(string xmlPath)
     {
-        using var stream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        return XDocument.Load(stream);
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var stream = new FileStream(xmlPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                return XDocument.Load(stream);
+            }
+            catch (IOException) when (attempt < LoadAttempts)
+            {
+                Thread.Sleep(LoadRetryDelayMs);
+            }
+            catch (XmlException) when (attempt < LoadAttempts)
+            {
+                Thread.Sleep(LoadRetryDelayMs);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Deletes the temp file, guarding only the delete so a cleanup failure cannot replace a real
+    /// assertion failure propagating out of the test.
+    /// </summary>
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // A transient lock on the temp file is not worth failing the test over.
+        }
     }
 }


### PR DESCRIPTION
## Why

`ProfileXmlDocTests` failed intermittently, and only ever on a solution-level `dotnet test ./src`. The failure was never captured in a TRX, so the starting point was a hypothesis rather than a finding.

It reproduces deterministically: `XDocument.Load(string)` opens the file with `FileShare.Read` — a share mode that refuses to coexist with an existing writer — so the read throws `IOException: The process cannot access the file because it is being used by another process` whenever another process holds `NetPace.Core.xml` open for writing. That file is a build-copied artefact sitting in the test project's own output directory, so an overlapping build can hold it.

Verified before changing anything: holding a competing write handle reproduced the exact exception, and reverting the fix still fails the new test today.

## What changes

Test-only. No production code changed.

- The XML doc is opened with `FileShare.ReadWrite` instead of via `XDocument.Load(string)`, so a concurrent writer can no longer fail the read.
- A regression test holds a competing write handle and asserts the load still succeeds — a deterministic assertion in place of a timing-dependent race.

## Non-obvious things a reviewer should know

**The regression test only discriminates on Windows.** Only Windows enforces share modes; on Unix .NET does not, so the pre-fix load would have succeeded there. The test still runs and still asserts the outcome on every platform — nothing is skipped (Principle X) — but since CI is `ubuntu-latest` only, **CI would not catch a revert of `LoadXmlDoc`**. The premise is asserted under `OperatingSystem.IsWindows()` rather than assumed, so the test reports if it ever stops proving anything on the platform where it does discriminate. This is documented at the site. Adding a Windows CI leg would close the gap but changes CI cost for the whole repo, so it is left as a deliberate follow-up rather than folded into this branch.

**The test uses a private temp file, not the real build artefact.** An earlier draft opened `NetPace.Core.xml` itself for writing, which risked the test contending for the very file the suite reads. The file-sharing behaviour under test is identical on any path.

**This pins a mechanism deliberately** (Principle IX regression exception) — it exists to stop a specific past failure returning.

## How to verify

- [ ] `dotnet build ./src` — zero warnings
- [ ] `dotnet test ./src` — 617 tests, 0 skipped
- [ ] On Windows, revert `LoadXmlDoc` to `XDocument.Load(xmlPath)` and confirm `LoadXmlDoc_WhileAConcurrentWriterHoldsTheFile_StillLoadsTheDocument` fails with `IOException`
- [ ] Confirm no production code is touched

## Related

Pre-existing, introduced in #199 Profile CLI Switch. Unrelated to #206.

Separately observed while soak-testing this branch: `OoklaSpeedtestTests.GetServerLatencyAsync_..._MultipleTestIterations` is independently flaky — it asserts a wall-clock latency within ±25% of a simulated delay and overshoots under machine load (142ms and 85ms against a 45–75ms band, twice in an 8-run soak). Not touched here; worth its own issue.