### PR TITLE
Record Latency Flake Memory

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -22,3 +22,4 @@
 - [Soft-wrap markdown — one line per paragraph](feedback_markdown_soft_wrap.md) — no manual ~80/100-col hard breaks; they reflow whole blocks and bury one-word edits in noisy diffs
 - [Explain tradeoffs in plain language before asking the user to decide](feedback_plain_language_decisions.md) — frame AskUserQuestion options by consequence/cost, not mechanism
 - [Audit the failure class after the second occurrence](feedback_audit_class_after_two_failures.md) — on the 2nd same-shape failure, enumerate every site and fix the class, not the instance
+- [OoklaSpeedtest latency-margin test is flaky under load](project_flaky_latency_margin_test.md) — wall-clock ±25% assertion; distinct from the ProfileXmlDocTests FileShare flake

--- a/.claude/memory/project_flaky_latency_margin_test.md
+++ b/.claude/memory/project_flaky_latency_margin_test.md
@@ -1,0 +1,12 @@
+---
+name: project_flaky_latency_margin_test
+description: OoklaSpeedtestTests latency-margin test flakes under machine load — separate from the ProfileXmlDocTests file-sharing flake
+metadata:
+  type: project
+---
+
+`OoklaSpeedtestTests.GetServerLatencyAsync_ShouldReturnLatency_WhenResponseIsValid_MultipleTestIterations` is flaky. It asserts measured latency lands within a ±25% margin of a simulated `pingDelay` (`OoklaSpeedtestTests.cs:225`), which a loaded machine overshoots — observed at 142ms and 85ms against a 45–75ms band, twice in an 8-run solution-level soak on 2026-08-27.
+
+**Why:** it is a wall-clock assertion, so it measures the host's scheduling latency as much as the code's. It is unrelated to the `ProfileXmlDocTests` `FileShare` flake fixed on `fix/profile-xmldoc-file-sharing` — that one was an `IOException` from a concurrent writer, and it did not recur across ~30 solution runs after the fix. Do not conflate the two: an earlier uncaptured solution-run failure during that work was most likely this test, not the XML-doc one.
+
+**How to apply:** when a solution-level `dotnet test ./src` goes red on one Core.Tests case, check the test name before assuming a regression — capture a TRX (`--logger "trx;LogFileName=x.trx" --results-directory ...`) rather than filtering the console, since these failures are intermittent and the console detail is easily lost. Fixing it properly means removing the wall-clock dependency (inject a clock / assert on the mocked delay), not widening the margin. See [[feedback_rerun_tests_before_done]].

--- a/.claude/memory/project_flaky_latency_margin_test.md
+++ b/.claude/memory/project_flaky_latency_margin_test.md
@@ -1,8 +1,7 @@
 ---
-name: project_flaky_latency_margin_test
+name: OoklaSpeedtest latency-margin test is flaky under load
 description: OoklaSpeedtestTests latency-margin test flakes under machine load — separate from the ProfileXmlDocTests file-sharing flake
-metadata:
-  type: project
+type: project
 ---
 
 `OoklaSpeedtestTests.GetServerLatencyAsync_ShouldReturnLatency_WhenResponseIsValid_MultipleTestIterations` is flaky. It asserts measured latency lands within a ±25% margin of a simulated `pingDelay` (`OoklaSpeedtestTests.cs:225`), which a loaded machine overshoots — observed at 142ms and 85ms against a 45–75ms band, twice in an 8-run solution-level soak on 2026-08-27.


### PR DESCRIPTION
## Why

`OoklaSpeedtestTests.GetServerLatencyAsync_ShouldReturnLatency_WhenResponseIsValid_MultipleTestIterations` is flaky, and nothing in the repo recorded that. It surfaced while soak-testing an unrelated branch: two failures in an 8-run solution-level `dotnet test ./src`, measuring 142ms and 85ms against a 45–75ms band.

The assertion compares a measured wall-clock latency against a ±25% margin around a simulated ping delay ([OoklaSpeedtestTests.cs:225](../blob/main/src/NetPace.Core.Tests/OoklaSpeedtestTests.cs#L225)), so under load it measures the host's scheduling as much as the code's behaviour.

Worth writing down for two reasons: the next person to hit a red solution run shouldn't re-diagnose it from scratch, and it should not be confused with the `ProfileXmlDocTests` file-sharing flake fixed in #237 — that one was an `IOException` from a concurrent writer, and it did not recur across ~30 solution runs after the fix. An earlier uncaptured failure during that work was most likely this test, not the XML-doc one.

## What changes

Project memory only — no code, no tests, no docs.

- Adds `.claude/memory/project_flaky_latency_margin_test.md` describing the flake, why it happens, and how to capture it next time (a TRX logger rather than filtering the console, since the detail is easily lost).
- Adds its one-line pointer to the `MEMORY.md` index.

## Non-obvious things a reviewer should know

The note deliberately says the fix is to remove the wall-clock dependency — inject a clock, or assert against the mocked delay — **not** to widen the margin. Widening would keep the test green while further weakening what it verifies.

No fix is attempted here. Recording the finding and fixing the test are separate missions, and this branch is only the former.

## Related

- #237 — the `ProfileXmlDocTests` file-sharing flake this one is explicitly distinguished from.