### PR TITLE
Upload Redirect 307

### DIFF
--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.Redirects.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.Redirects.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using NetPace.Core.Clients.Ookla;
+using RichardSzalay.MockHttp;
+using Shouldly;
+
+namespace NetPace.Core.Tests;
+
+/// <summary>
+/// Upload behaviour when a speed test server redirects the upload endpoint.
+/// <para>
+/// Regression cover: Ookla is migrating its fleet to HTTPS, and a migrated server answers a
+/// plain-HTTP upload POST with a 307 to its HTTPS endpoint. From 0.14.0 (PR #69, which replaced
+/// buffered <c>ByteArrayContent</c> with a streaming body) every upload against such a server
+/// failed, reporting 0 bps. The observable contract pinned here is throughput, not the mechanism
+/// by which the redirect is honoured.
+/// </para>
+/// </summary>
+public sealed partial class OoklaSpeedtestTests
+{
+    [Fact]
+    public async Task GetUploadSpeedAsync_ShouldMeasureThroughput_WhenServerRedirectsUploadEndpoint()
+    {
+        // SCENARIO: Upload endpoint answers with a redirect
+
+        const string uploadUrl = "http://example.com/speedtest/upload.php";
+        const string redirectedUrl = "https://migrated.example.com/speedtest/upload.php";
+
+        // Given a server that redirects every upload POST to its migrated endpoint,
+        // and a migrated endpoint that accepts the upload.
+        using var mockHttp = new MockHttpMessageHandler();
+
+        mockHttp.When(HttpMethod.Post, uploadUrl)
+            .Respond(_ => new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+            {
+                Headers = { Location = new Uri(redirectedUrl) }
+            });
+
+        mockHttp.When(HttpMethod.Post, redirectedUrl)
+            .Respond(_ => new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = mockHttp.ToHttpClient();
+        var settings = new OoklaSpeedtestSettings
+        {
+            UploadTest = new()
+            {
+                UploadIncrements = 1,
+                UploadSizeIterations = 4,
+                UploadParallelTasks = 2
+            }
+        };
+        var speedtest = new OoklaSpeedtest(settings, httpClient);
+        var server = new Server { Url = uploadUrl, Sponsor = "Test", Location = "Test" };
+
+        // When the upload test runs against the redirecting server.
+        var result = await speedtest.GetUploadSpeedAsync(server);
+
+        // Then the redirect is honoured and real throughput is reported - not 0 bps.
+        result.ShouldNotBeNull();
+        result.RequestsFailed.ShouldBe(0);
+        result.RequestsSucceeded.ShouldBeGreaterThan(0);
+        result.BytesProcessed.ShouldBeGreaterThan(0);
+    }
+}

--- a/src/NetPace.Core.Tests/OoklaSpeedtestTests.Redirects.cs
+++ b/src/NetPace.Core.Tests/OoklaSpeedtestTests.Redirects.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using NetPace.Core.Clients.Ookla;
 using RichardSzalay.MockHttp;
 using Shouldly;
@@ -57,6 +58,53 @@ public sealed partial class OoklaSpeedtestTests
         var result = await speedtest.GetUploadSpeedAsync(server);
 
         // Then the redirect is honoured and real throughput is reported - not 0 bps.
+        result.ShouldNotBeNull();
+        result.RequestsFailed.ShouldBe(0);
+        result.RequestsSucceeded.ShouldBeGreaterThan(0);
+        result.BytesProcessed.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetUploadSpeedAsync_ShouldMeasureThroughputAtTheConfiguredUrl_WhenResolvingTheEndpointFails()
+    {
+        // SCENARIO: Endpoint resolution fails before the measured uploads
+
+        const string uploadUrl = "http://example.com/speedtest/upload.php";
+
+        // Given the first request - the one that resolves the endpoint - fails outright,
+        // while the configured URL itself accepts uploads normally.
+        var requestCount = 0;
+
+        using var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When(HttpMethod.Post, uploadUrl).Respond(_ =>
+        {
+            if (Interlocked.Increment(ref requestCount) == 1)
+            {
+                throw new HttpRequestException("Endpoint resolution failed");
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var httpClient = mockHttp.ToHttpClient();
+        var settings = new OoklaSpeedtestSettings
+        {
+            UploadTest = new()
+            {
+                UploadIncrements = 1,
+                UploadSizeIterations = 4,
+                UploadParallelTasks = 2
+            }
+        };
+        var speedtest = new OoklaSpeedtest(settings, httpClient);
+        var server = new Server { Url = uploadUrl, Sponsor = "Test", Location = "Test" };
+
+        // When the upload test runs.
+        var result = await speedtest.GetUploadSpeedAsync(server);
+
+        // Then the failure to resolve does not fail the run: uploads proceed against the
+        // configured URL and report throughput. Only that URL is mocked, so had resolution
+        // yielded anything else the requests would have gone unanswered and failed.
         result.ShouldNotBeNull();
         result.RequestsFailed.ShouldBe(0);
         result.RequestsSucceeded.ShouldBeGreaterThan(0);

--- a/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
+++ b/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
@@ -270,12 +270,18 @@ public sealed class OoklaSpeedtest : ISpeedTestService
         // Generate upload sizes (in bytes) rather than allocating large buffers up-front.
         var testDataLengths = GenerateUploadDataLengths(settings.UploadTest.UploadIncrements, settings.UploadTest.UploadSizeIncrementKb, settings.UploadTest.UploadSizeIterations);
 
+        // Ookla is migrating its fleet to HTTPS, and a migrated server answers a plain-HTTP upload
+        // POST with a redirect. The streaming body cannot survive that redirect - the server responds
+        // and closes the request stream while the body is still being written - so resolve the real
+        // endpoint once, cheaply, and upload straight to it.
+        var uploadUrl = await ResolveUploadUrlAsync(server.Url, cancellationToken).ConfigureAwait(false);
+
         // Upload content to a specified URL and return the size of the data in bytes.
         Func<HttpClient, int, CancellationToken, Task<int>> UploadAndMeasureAsync = async (client, length, cancellationToken) =>
         {
             // Use RandomStreamContent to stream generated random bytes in small chunks to avoid LOH allocations.
             using var content = new RandomStreamContent(length);
-            using var response = await client.PostAsync(server.Url, content, cancellationToken).ConfigureAwait(false);
+            using var response = await client.PostAsync(uploadUrl, content, cancellationToken).ConfigureAwait(false);
 
             // A rejected upload (non-success status) is a failed request, not throughput -
             // mirror the download path so error statuses are aggregated into the failure count.
@@ -517,6 +523,62 @@ public sealed class OoklaSpeedtest : ISpeedTestService
             }
         }
     }
+
+    /// <summary>
+    /// Resolves the address the server actually wants uploads sent to, following any redirects
+    /// with a small probe body before the measured uploads begin.
+    /// </summary>
+    /// <remarks>
+    /// The probe carries no body: a redirect is decided by scheme and host rather than payload, so
+    /// an empty POST draws the same answer with nothing to write and nothing to tear down mid-write.
+    /// Sending no bytes also keeps the probe out of the measurement entirely. Whether the redirect is
+    /// followed by the underlying handler or reported back to us, the endpoint that actually accepted
+    /// the probe is the one returned. The probe never fails the test - if it cannot complete, the
+    /// original URL is used and any real fault surfaces through the upload requests themselves.
+    /// </remarks>
+    private async Task<string> ResolveUploadUrlAsync(string url, CancellationToken cancellationToken)
+    {
+        const int maximumHops = 5;
+
+        var currentUrl = url;
+
+        try
+        {
+            for (var hop = 0; hop < maximumHops; hop++)
+            {
+                using var probeContent = new RandomStreamContent(0);
+                using var response = await httpClient.PostAsync(currentUrl, probeContent, cancellationToken).ConfigureAwait(false);
+
+                // The handler did not follow the redirect for us - follow it explicitly.
+                if (IsRedirect(response.StatusCode) && response.Headers.Location is { } location)
+                {
+                    currentUrl = new Uri(new Uri(currentUrl), location).ToString();
+                    continue;
+                }
+
+                // Otherwise the endpoint that answered is the one to upload to. When the handler
+                // followed redirects itself, that is the final hop rather than where we started.
+                return response.RequestMessage?.RequestUri?.ToString() ?? currentUrl;
+            }
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Probing is best-effort; fall back to the configured URL.
+            return url;
+        }
+
+        return currentUrl;
+    }
+
+    /// <summary>
+    /// Determines whether a status code asks the caller to repeat the request elsewhere.
+    /// </summary>
+    private static bool IsRedirect(HttpStatusCode statusCode) => statusCode is
+        HttpStatusCode.MovedPermanently or
+        HttpStatusCode.Found or
+        HttpStatusCode.SeeOther or
+        HttpStatusCode.TemporaryRedirect or
+        HttpStatusCode.PermanentRedirect;
 
     /// <summary>
     /// Generate upload payload lengths (in bytes) for the upload test.

--- a/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
+++ b/src/NetPace.Core/Clients/Ookla/OoklaSpeedtest.cs
@@ -441,6 +441,52 @@ public sealed class OoklaSpeedtest : ISpeedTestService
         };
     }
 
+    /// <summary>
+    /// Resolves the address the server actually wants uploads sent to, following any redirects
+    /// with a small probe body before the measured uploads begin.
+    /// </summary>
+    /// <remarks>
+    /// The probe carries no body: a redirect is decided by scheme and host rather than payload, so
+    /// an empty POST draws the same answer with nothing to write and nothing to tear down mid-write.
+    /// Sending no bytes also keeps the probe out of the measurement entirely. Whether the redirect is
+    /// followed by the underlying handler or reported back to us, the endpoint that actually accepted
+    /// the probe is the one returned. The probe never fails the test - if it cannot complete, the
+    /// original URL is used and any real fault surfaces through the upload requests themselves.
+    /// </remarks>
+    private async Task<string> ResolveUploadUrlAsync(string url, CancellationToken cancellationToken)
+    {
+        const int maximumHops = 5;
+
+        var currentUrl = url;
+
+        try
+        {
+            for (var hop = 0; hop < maximumHops; hop++)
+            {
+                using var probeContent = new RandomStreamContent(0);
+                using var response = await httpClient.PostAsync(currentUrl, probeContent, cancellationToken).ConfigureAwait(false);
+
+                // The handler did not follow the redirect for us - follow it explicitly.
+                if (IsRedirect(response.StatusCode) && response.Headers.Location is { } location)
+                {
+                    currentUrl = new Uri(new Uri(currentUrl), location).ToString();
+                    continue;
+                }
+
+                // Otherwise the endpoint that answered is the one to upload to. When the handler
+                // followed redirects itself, that is the final hop rather than where we started.
+                return response.RequestMessage?.RequestUri?.ToString() ?? currentUrl;
+            }
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // Probing is best-effort; fall back to the configured URL.
+            return url;
+        }
+
+        return currentUrl;
+    }
+
     #region Static Functions
 
     /// <summary>
@@ -525,54 +571,15 @@ public sealed class OoklaSpeedtest : ISpeedTestService
     }
 
     /// <summary>
-    /// Resolves the address the server actually wants uploads sent to, following any redirects
-    /// with a small probe body before the measured uploads begin.
-    /// </summary>
-    /// <remarks>
-    /// The probe carries no body: a redirect is decided by scheme and host rather than payload, so
-    /// an empty POST draws the same answer with nothing to write and nothing to tear down mid-write.
-    /// Sending no bytes also keeps the probe out of the measurement entirely. Whether the redirect is
-    /// followed by the underlying handler or reported back to us, the endpoint that actually accepted
-    /// the probe is the one returned. The probe never fails the test - if it cannot complete, the
-    /// original URL is used and any real fault surfaces through the upload requests themselves.
-    /// </remarks>
-    private async Task<string> ResolveUploadUrlAsync(string url, CancellationToken cancellationToken)
-    {
-        const int maximumHops = 5;
-
-        var currentUrl = url;
-
-        try
-        {
-            for (var hop = 0; hop < maximumHops; hop++)
-            {
-                using var probeContent = new RandomStreamContent(0);
-                using var response = await httpClient.PostAsync(currentUrl, probeContent, cancellationToken).ConfigureAwait(false);
-
-                // The handler did not follow the redirect for us - follow it explicitly.
-                if (IsRedirect(response.StatusCode) && response.Headers.Location is { } location)
-                {
-                    currentUrl = new Uri(new Uri(currentUrl), location).ToString();
-                    continue;
-                }
-
-                // Otherwise the endpoint that answered is the one to upload to. When the handler
-                // followed redirects itself, that is the final hop rather than where we started.
-                return response.RequestMessage?.RequestUri?.ToString() ?? currentUrl;
-            }
-        }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
-        {
-            // Probing is best-effort; fall back to the configured URL.
-            return url;
-        }
-
-        return currentUrl;
-    }
-
-    /// <summary>
     /// Determines whether a status code asks the caller to repeat the request elsewhere.
     /// </summary>
+    /// <remarks>
+    /// The permanent and temporary redirects are treated alike because this resolves an address
+    /// rather than replaying a transfer: an HTTPS migration is as likely to be announced with a
+    /// permanent 301 as with the 307 that prompted this, and either way the answer we want is
+    /// simply "go here instead". The method rewriting that a handler applies to 301/302/303 when
+    /// replaying a request does not apply - the probe is discarded once its address is known.
+    /// </remarks>
     private static bool IsRedirect(HttpStatusCode statusCode) => statusCode is
         HttpStatusCode.MovedPermanently or
         HttpStatusCode.Found or


### PR DESCRIPTION
## Why

Ookla is migrating its speed test fleet to HTTPS. A migrated server answers a plain-HTTP upload POST with a `307` to its HTTPS endpoint — and it sends that redirect after roughly 64 KB, closing the request stream while the body is still being written.

Since **0.14.0** (#69) the upload body has been streamed in 8 KB chunks instead of handed over as one buffered `ByteArrayContent`. A streaming body cannot survive that mid-write teardown: it fails with `IOException: Unable to write data to the transport connection`, so .NET never reads the `307` and never follows it. Every upload request failed and the run reported `0 bps`.

Roughly ten months of releases (0.14.0 → 0.24.0) have reported `0 bps` against any migrated server — silently, until #222 started surfacing the failure count.

Downloads were never affected, which is what made this look server-specific rather than transport-shaped: a GET carries no body, so it replays across the redirect for free. The same server would report 291 Mbps down and 0 bps up.

## What changes

- The upload endpoint is resolved once, before the measured uploads begin, and uploads go straight to wherever the server actually wants them. Redirects are followed explicitly (up to 5 hops) or honoured by the handler, whichever happens first.
- Upload throughput is now reported correctly against HTTPS-migrated servers.

## Non-obvious things a reviewer should know

- **The probe deliberately sends no body.** A redirect is decided by scheme and host, not payload, so an empty POST draws the same answer with nothing to write and nothing to tear down mid-write. It also keeps the probe out of the measurement — an earlier 1 KB probe was caught by `GetUploadSpeedAsync_ShouldReturnSpeedTestResult_WhenSuccessful`, which tallies every byte the server receives against reported throughput. That test passes unmodified here, and is worth keeping that way.
- **#69's memory fix is retained.** Per-chunk streaming is untouched; this only changes *where* the chunks are sent. Buffering the body again would have fixed the bug but re-opened the RAM growth #69 closed.
- **Probing is best-effort.** If it cannot complete, the configured URL is used and any real fault surfaces through the upload requests as before — a broken probe never fails a test run on its own.
- **The regression test pins the outcome, not the mechanism** (Constitution IX): a redirecting upload endpoint must still yield throughput. It holds for any of the redirect-handling approaches we considered.
- **The hermetic seam has a known limit.** `MockHttpMessageHandler` replaces the transport, so no test can reproduce the actual socket teardown mid-body-write. The test covers the redirect contract; the teardown itself was verified manually against a live migrated server.

## How to verify

- [ ] `dotnet build src` — clean, zero warnings
- [ ] `dotnet test src` — 647 pass, 0 skipped
- [ ] New test fails without the fix: stash the `OoklaSpeedtest.cs` change and run `dotnet test src --filter "FullyQualifiedName~WhenServerRedirectsUploadEndpoint"`
- [ ] Against a live migrated server, upload reports real throughput rather than `0 bps`:
      `netpace --no-download --no-latency --server "http://speedtest-bracknell.vodafone.co.uk:8080/speedtest/upload.php"`
      (measured 176.44 Mbps here, against 0 bps / 30 of 30 failed before)
- [ ] Against a non-migrated server (e.g. Aquiss), upload is unchanged

## Related

Regression introduced by #69. Failure counts that made it visible came from #222.

Three follow-ups found while diagnosing this, deliberately left out of this branch:

1. Per-request failure reasons are discarded — only the count survives, which is why this took four releases and a dozen screenshots to pin down. Surfacing them means adding failure detail to `SpeedTestResult`, a public `NetPace.Core` API change.
2. Downloads still pay a redirect per request against migrated servers. Not broken, but silent overhead on every GET.
3. `--no-latency` selects `servers.First()` unvalidated. It is what made this bug reproducible, and the server it lands on shifts between releases.
