### PR TITLE
Ship Namespaced Reviewer Agents

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -40,7 +40,7 @@ Read `CLAUDE.md` for project context before proceeding.
    - **Green ⇒ continue.**
 
 2. **Clean-context review (synchronous — this is Review A).** Spawn independent, clean-context reviewer subagents over the branch diff (`git diff main...HEAD`), then run a `/review-slop` pass. The clean-context subagents must not see the code being written — "do not inline the review" governs the *reviewing*. The *deciding-and-fixing* legitimately happens in `/ship`'s own main loop.
-   - Spawn the `pr-review-toolkit` reviewers that apply to this diff. Most **report** findings — `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `type-design-analyzer`, `comment-analyzer` return findings; only `code-simplifier` edits files directly. Launch them in parallel (independent, clean-context Task subagents).
+   - Spawn the `pr-review-toolkit` reviewers that apply to this diff. Most **report** findings — `pr-review-toolkit:code-reviewer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:pr-test-analyzer`, `pr-review-toolkit:type-design-analyzer`, `pr-review-toolkit:comment-analyzer` return findings; only `pr-review-toolkit:code-simplifier` edits files directly. The `pr-review-toolkit:` prefix is required — the bare names do not resolve. Launch them in parallel (independent, clean-context Task subagents).
    - Run `/review-slop`, which emits a cleaned diff.
    - **`/ship`'s main loop applies a severity policy.** Aggregate the returned findings and cleaned diff. For each finding, first *validate it is real* — reviewer severities are fickle, so do not act on a mislabelled or false-positive finding — then act by severity:
      - **Blocker / P1** (a correctness bug, breakage, or anything that would ship broken) — **must be resolved.** Fix it in the working tree. If a confirmed blocker genuinely cannot be fixed, **STOP and report**; `/ship` never raises a PR over a known blocker.
@@ -49,7 +49,7 @@ Read `CLAUDE.md` for project context before proceeding.
    Apply the warranted edits to the working tree. Every applied edit is re-verified by step 3's suite re-run, so a bad fix cannot ship green-unchecked.
    - If a review subagent errors, STOP and report (stop-on-failure).
 
-3. **Conditional re-verify + commit the fixes.** Because step 0 required a clean tree, `git status --porcelain` now shows exactly what step 2 changed — from *any* source (the loop's own fixes **and** any files `code-simplifier` edited directly) — and nothing else.
+3. **Conditional re-verify + commit the fixes.** Because step 0 required a clean tree, `git status --porcelain` now shows exactly what step 2 changed — from *any* source (the loop's own fixes **and** any files `pr-review-toolkit:code-simplifier` edited directly) — and nothing else.
    - **If `git status --porcelain` is empty (step 2 changed nothing):** skip both the re-run and the commit — go to step 4. (No spurious second suite run.)
    - **If it is non-empty (step 2 applied edits):**
      - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.


### PR DESCRIPTION
## Why

`/ship` step 2 named the six `pr-review-toolkit` reviewers bare — `code-reviewer`, `silent-failure-hunter`, and so on. Those ids do not resolve; the plugin registers each as `pr-review-toolkit:<agent>`.

The failure mode is the bad kind. An agent following the instruction either errors out (loud, recoverable) or reads the available-agents list in the error and quietly substitutes `general-purpose` — a review that still runs, still reports, and no longer has any of the specialist prompts behind it. Nothing in the output would say so.

## Non-obvious things a reviewer should know

- **Only line 43 was load-bearing.** A repo-wide sweep found the six names in exactly two places: the spawn instruction (line 43) and one prose mention of `code-simplifier` (line 52). The prose one cannot break a spawn, but it is prefixed too so there is a single convention and no ambiguity for the next reader.
- **A sentence was added to line 43** — *"The `pr-review-toolkit:` prefix is required — the bare names do not resolve"* — so anyone later tidying the names back to something shorter has the reason in front of them.
- **This was only reachable after a separate fix.** The plugin had been installed with `--scope project` pinned to an unrelated repository, so it was enabled in settings and loaded nowhere. It is now installed at user scope. That was a change on the box, not in this repo, and is not part of this PR.
- **Three agents self-report a different name than their registered id** — `comment-analyzer` says "code-comment-analyzer", `pr-test-analyzer` says "test-coverage-analyzer", `silent-failure-hunter` says "error-handling-auditor". Harmless, since spawning uses the registered id, but worth knowing if anything ever matches on the self-reported name.

## How to verify

- [ ] Parse the ids straight out of the file rather than retyping them — expect six:

  ```bash
  sed -n '43p' .claude/commands/ship.md | grep -oE 'pr-review-toolkit:[a-z-]+' | sort -u
  ```

- [ ] Spawn each parsed id. All six should resolve and return.
- [ ] Negative control: spawn bare `code-reviewer`. It should fail with `Agent type 'code-reviewer' not found`.
- [ ] Confirm no bare names remain anywhere — expect no hits:

  ```bash
  grep -rnE '\`(code-reviewer|silent-failure-hunter|pr-test-analyzer|type-design-analyzer|comment-analyzer|code-simplifier)\`' --include='*.md' .
  ```

All four were run before raising this. What is **not** covered is a full `/ship` run: this proves the six ids resolve and the agents start, not that step 2 produces useful findings on a real diff. That behaviour is unchanged by this PR.

## Related

Surfaced while reviewing #235, where the underlying finding is recorded under **Confirmed decisions**. The fix itself is deliberately kept out of that issue — #235 is a four-item harness sync and this is a fifth, unrelated defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmcTTPDWWeAmUfkqgDiNA4
