### PR TITLE
Plugin Report Exec And Stats

### DIFF
--- a/scripts/plugin-report.sh
+++ b/scripts/plugin-report.sh
@@ -268,6 +268,9 @@ perf() {
   printf '%s\n' "$out" | sed 's/^/  /'
 }
 if [ $rtk_inst -eq "$YES" ]; then perf rtk rtk gain; else echo "rtk: n/a — not installed"; fi
-if [ -x "$ro_dir/read-once" ]; then perf read-once "$ro_dir/read-once" verify; else echo "read-once: n/a — not installed"; fi
+# `stats`, not `verify` (#252). read-once's counters subcommand is `stats`; `verify` is its 13-point
+# installation check, already run above as the TOOLING reachability probe — printing it here filled
+# a counter row with a checklist that exits 0, so a missing figure read as a healthy report.
+if [ -x "$ro_dir/read-once" ]; then perf read-once "$ro_dir/read-once" stats; else echo "read-once: n/a — not installed"; fi
 if [ $cm_inst -eq "$YES" ]; then echo "context-mode: installed — counters are MCP-only; run ctx_stats in-session"; else echo "context-mode: $(yn $cm_inst) — no shell-visible counters"; fi
 echo "pr-review-toolkit: n/a — exposes no counters"

--- a/scripts/plugin-report.sh
+++ b/scripts/plugin-report.sh
@@ -268,9 +268,11 @@ perf() {
   printf '%s\n' "$out" | sed 's/^/  /'
 }
 if [ $rtk_inst -eq "$YES" ]; then perf rtk rtk gain; else echo "rtk: n/a — not installed"; fi
-# `stats`, not `verify` (#252). read-once's counters subcommand is `stats`; `verify` is its 13-point
-# installation check, already run above as the TOOLING reachability probe — printing it here filled
-# a counter row with a checklist that exits 0, so a missing figure read as a healthy report.
+# `stats`, not `verify` (issue #252). The two calls deliberately use different subcommands, and
+# making them agree is the wrong refactor: the TOOLING reachability probe above runs `verify`,
+# read-once's full diagnostic, while counters live under `stats` (`gain` is an alias for it).
+# `verify` here would fill a counter row with a checklist that exits 0, so the missing figure
+# would read as a healthy report.
 if [ -x "$ro_dir/read-once" ]; then perf read-once "$ro_dir/read-once" stats; else echo "read-once: n/a — not installed"; fi
 if [ $cm_inst -eq "$YES" ]; then echo "context-mode: installed — counters are MCP-only; run ctx_stats in-session"; else echo "context-mode: $(yn $cm_inst) — no shell-visible counters"; fi
 echo "pr-review-toolkit: n/a — exposes no counters"


### PR DESCRIPTION
Closes #252

## Why

Both defects were invisible in normal use, which is why they survived. The missing exec bit stayed hidden because every documented invocation is `bash scripts/plugin-report.sh`; the wrong subcommand stayed hidden because `read-once verify` **exits 0**, so a counter row full of `[ok]` checklist lines read as a successful report rather than a missing figure. A script whose whole product is a truthful yes/no had committed the exact sin it exists to catch in other tooling.

## What changes

- The PERFORMANCE section reports read-once's counters (`stats`) instead of its diagnostic checklist (`verify`). On a box with nothing captured it now prints read-once's own honest line: `No read-once data yet. Stats appear after your first Claude Code session with the hook installed.`
- `scripts/plugin-report.sh` is now `100755`, matching every sibling in `scripts/` and `.claude/hooks/`. **This is not visible in the content diff** — use `git diff main...HEAD --summary` to see the `100644 => 100755` mode change.

## Non-obvious things a reviewer should know

**The two calls to read-once are deliberately inconsistent, and "harmonising" them would reinstate the bug.** Line 155 keeps `verify` (it drives the TOOLING `reachable=` column); line 274 uses `stats`. Issue #252 states the constraint — "Line 155 should keep `verify`; only the PERFORMANCE row changes" — but that constraint existed nowhere in the code, so the review added it to the comment. Note also that `read-once gain` is an alias for `stats`, and the line immediately above is `perf rtk rtk gain`, which makes the wrong refactor look especially reasonable.

**This PR ships no committed tests, deliberately.** Issue #235's confirmed decisions record the author's explicit call: *"plugin-report.sh ... with no plugin-report.tests.sh ... it is a one-off manually-run script, not a gate."* RED-GREEN was driven by a 14-case harness in the gitignored `.claude/scratch/`, which fails 6/12 against `main` and passes on this branch. **That decision is worth a fresh look** — #252 is two defects a committed matrix would have caught, and the harness that caught them is about to be deleted with the scratch tree. Landing that file as-is at `scripts/plugin-report.tests.sh` would be minutes of work, but it has a documented author decision against it, so it is your call rather than something this PR should override.

## How to verify

- [ ] `./scripts/plugin-report.sh` runs directly without `bash` and exits 0.
- [ ] `git diff main...HEAD --summary` shows `mode change 100644 => 100755`.
- [ ] The PERFORMANCE section's read-once row shows counters or a "no data" message, not a list of `[ok]` lines.
- [ ] The TOOLING row still reads `read-once: ... reachable=yes` — that column must still come from `verify`.

## Deferred review findings

Clean-context review raised these. All were confirmed real but concern **pre-existing** code this branch does not touch (the diff is a single hunk, `@@ -271 +271,4 @@`), so they are recorded here rather than folded in per CLAUDE.md's "don't fold a second mission into an in-flight branch".

| # | Finding | Notes |
|---|---|---|
| 1 | `probe()` feeds a **raw exit code** into `yn()`, which maps `3` → `n/a` ("no probe for this cell") and `2` → `unknown`. A hard failure can report as "we never asked". | Safe only by luck today: `read-once verify` uses 0/1 and `rtk --version` returns 0. `rtk` is clap-based and clap uses exit 2 for usage errors. Lines 74-86, 155, 170. |
| 2 | `installed` uses `[ -d ]` (:153) but the PERFORMANCE guard uses `[ -x ]` (:274), so a present-but-non-executable binary prints `installed=yes` **and** `n/a — not installed` in the same run. | Two sections contradicting each other. Thematically apt given this PR. |
| 3 | `NETPACE_CLAUDE_HOME` selects which read-once **binary** runs, but read-once hardcodes `CACHE_DIR="${HOME}/.claude/read-once"`, so the counters always come from the default home. | Newly material now that the row carries home-dependent data. Only bites under the diagnostic override. |
| 4 | A read-once predating `stats` surfaces as `PROBE FAILED (exit 1)`, blaming the tool for the report's own assumption. | Not silent — the cause is printed — but the headline misattributes. Now covered in the harness. |
| 5 | `timeout` exit 124 reports as `PROBE FAILED`, where the file's own rule says a timeout is "could not look" → `unknown`. | Same class as #1. |
| 6 | `"${TIMEOUT[@]}"` on an empty array under `set -u` aborts on bash < 4.4; macOS ships 3.2 and has no `timeout(1)`, so the array is empty exactly there. | Reported by review; **not verified here** (this box runs bash 5.x). Fix is `"${TIMEOUT[@]+"${TIMEOUT[@]}"}"`. |
| 7 | All three documented call sites still use `bash scripts/plugin-report.sh` (`docs/agentic-workflow-NetPace.md:105`, `.claude/commands/install-harness-tooling.md:13` and `:62`). | Flagged by three of four reviewers. Switching them to `./scripts/plugin-report.sh` would make the documented workflow a regression detector for the exec bit. |

One finding was graded **Blocker** and is deliberately not fixed: that `read-once stats` exits 0 both when there is genuinely no data and when its stats file is unreadable, so the row cannot tell them apart. The facts check out, but this is read-once's own behaviour, and AC2 explicitly asks for "read-once's own 'no data yet' message". The proposed fix would couple this script to read-once's private `--json` schema — the exact coupling its header warns against for `.plugins[k][].installPath`. Worth an upstream issue, not a change here.

## Related

- Closes #252
- Formatting (`/ship` step 1a) was **skipped** — #249 is still open, and `dotnet format whitespace` currently rewrites all 79 `.cs` files. This branch touches no C#, so the step was a no-op for it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFuh2edjRehoFbZh2BnXUW
