### PR TITLE
Permissions Push Allow Chmod Ask

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,7 @@
       "Bash(git commit:*)",
       "Bash(git checkout:*)",
       "Bash(git restore:*)",
+      "Bash(git push:*)",
       "Bash(cd \"d:/Source/Repos/NetPace\":*)",
       "Bash(.specify/scripts/bash/:*)",
       "Bash(dotnet build:*)",
@@ -67,7 +68,6 @@
     "deny": [
       "Bash(sudo:*)",
       "Bash(su:*)",
-      "Bash(chmod:*)",
       "Bash(chown:*)",
       "Bash(curl:*)",
       "Bash(wget:*)",
@@ -84,7 +84,7 @@
       "Edit(.specify/scripts/bash/*.sh)"
     ],
     "ask": [
-      "Bash(git push:*)"
+      "Bash(chmod:*)"
     ],
     "defaultMode": "acceptEdits"
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,12 +73,6 @@
       "Bash(wget:*)",
       "Bash(ssh:*)",
       "Bash(scp:*)",
-      "Read(**/.env)",
-      "Read(**/.env.*)",
-      "Read(**/secrets.*)",
-      "Read(**/.ssh/**)",
-      "Read(**/appsettings.*.json)",
-      "Read(**/appsettings.json)",
       "Edit(.claude/skills/speckit-*/SKILL.md)",
       "Edit(.specify/templates/*.md)",
       "Edit(.specify/scripts/bash/*.sh)"

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -91,7 +91,7 @@ An `ask`-matched call **prompts** in an interactive session but is **silently de
 
 That asymmetry makes headless a permission oracle — run a workflow under `claude -p --dangerously-skip-permissions` and anything that would have prompted interactively comes back denied instead, with no human in the loop to mask it. Not CI-gateable: it needs the `claude` binary and an authenticated session.
 
-`Bash(rm:*)` and `Bash(rmdir:*)` came off the list for this reason ([CIR](change-intent-records/2026-09-04-rm-off-the-ask-list.md)), and `Bash(chmod:*)` moved onto it from `deny` — which buys an approval path interactively but not in a lane worker, where `ask` still denies silently ([CIR](change-intent-records/2026-09-04-push-allow-chmod-ask.md)).
+`Bash(rm:*)` and `Bash(rmdir:*)` came off the list for this reason ([CIR](change-intent-records/2026-09-04-rm-off-the-ask-list.md)), and `Bash(git push:*)` followed them off it into `allow` — that is what lets `/ship` reach `gh pr create` without stopping at its second-to-last step. `Bash(chmod:*)` moved the other way, from `deny` onto `ask`, which buys an approval path interactively but not in a lane worker, where `ask` still denies silently ([CIR](change-intent-records/2026-09-04-push-allow-chmod-ask.md)).
 
 ## Test-green gate & categories
 

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -89,9 +89,11 @@ NetPace's `/ship` follows the generic *ship gate* section as written:
 
 An `ask`-matched call **prompts** in an interactive session but is **silently denied** in a headless `claude -p` one, which cannot draw a prompt: the worker loses that capability and carries on degraded. A green unattended run is therefore not evidence that its `ask` rules were harmless.
 
-That asymmetry makes headless a permission oracle — run a workflow under `claude -p --dangerously-skip-permissions` and anything that would have prompted interactively comes back denied instead, with no human in the loop to mask it. Not CI-gateable: it needs the `claude` binary and an authenticated session.
+That asymmetry makes headless a permission oracle **for rule matching** — run a workflow under `claude -p --dangerously-skip-permissions` and whatever an `allow`, `ask` or `deny` rule would have stopped comes back denied, with no human in the loop to mask it. Know its blind spot: the escalations that need an interactive surface do not fire headlessly at all. A recursive `grep` whose read scope overlaps a `Read(…)` deny rule prompts interactively and runs clean under `claude -p`, so the oracle reports a false all-clear. It answers "which rule matched", not "would a human have been asked". Not CI-gateable either way: it needs the `claude` binary and an authenticated session.
 
 `Bash(rm:*)` and `Bash(rmdir:*)` came off the list for this reason ([CIR](change-intent-records/2026-09-04-rm-off-the-ask-list.md)), and `Bash(git push:*)` followed them off it into `allow` — that is what lets `/ship` reach `gh pr create` without stopping at its second-to-last step. `Bash(chmod:*)` moved the other way, from `deny` onto `ask`, which buys an approval path interactively but not in a lane worker, where `ask` still denies silently ([CIR](change-intent-records/2026-09-04-push-allow-chmod-ask.md)).
+
+`permissions.deny` no longer carries `Read(…)` rules. It held six, over `.env`, `secrets.*`, `.ssh/**` and `appsettings*.json`, and any of them made a recursive read of the repo escalate to an approval no mode auto-grants — the check is glob-scope-based, not existence-based, so it fired even though the repo contains none of those files ([CIR](change-intent-records/2026-09-04-read-deny-rules-removed.md)).
 
 ## Test-green gate & categories
 

--- a/docs/agentic-workflow-NetPace.md
+++ b/docs/agentic-workflow-NetPace.md
@@ -91,7 +91,7 @@ An `ask`-matched call **prompts** in an interactive session but is **silently de
 
 That asymmetry makes headless a permission oracle — run a workflow under `claude -p --dangerously-skip-permissions` and anything that would have prompted interactively comes back denied instead, with no human in the loop to mask it. Not CI-gateable: it needs the `claude` binary and an authenticated session.
 
-`Bash(rm:*)` and `Bash(rmdir:*)` came off the list for this reason ([CIR](change-intent-records/2026-09-04-rm-off-the-ask-list.md)).
+`Bash(rm:*)` and `Bash(rmdir:*)` came off the list for this reason ([CIR](change-intent-records/2026-09-04-rm-off-the-ask-list.md)), and `Bash(chmod:*)` moved onto it from `deny` — which buys an approval path interactively but not in a lane worker, where `ask` still denies silently ([CIR](change-intent-records/2026-09-04-push-allow-chmod-ask.md)).
 
 ## Test-green gate & categories
 

--- a/docs/change-intent-records/2026-09-04-push-allow-chmod-ask.md
+++ b/docs/change-intent-records/2026-09-04-push-allow-chmod-ask.md
@@ -3,22 +3,24 @@
 **Intent:** Stop `/raise-pr` stalling at its push step, and stop `chmod` being a hard block with no approval path.
 
 **Behaviour:**
-- Given a `/ship` run in the project's own `defaultMode`, when it reaches `/raise-pr` step 7, then the push proceeds without a prompt.
-- Given an agent that needs to set an executable bit, when it runs `chmod`, then the decision is surfaced rather than refused outright.
+- Given a `/ship` run in the project's own `defaultMode`, when it reaches `/raise-pr`'s push step, then the push proceeds without a prompt.
+- Given an agent in an interactive session that needs to set an executable bit, when it runs `chmod`, then the decision is surfaced rather than refused outright. In a headless worker it is still refused — see the caveat below.
 - Given a command naming privilege escalation (`sudo`, `su`, `chown`) or a network binary (`curl`, `wget`, `ssh`, `scp`), when it runs in any mode, then it is still refused.
 
 **Constraints:**
 - `deny` is enforced even in `bypassPermissions`, so a deny rule is a silent hard block mid-agent — no prompt, no approval path. That is right for exfiltration and privilege escalation, and wrong for a local file-mode change that grants no capability a shell does not already have.
-- The matcher scans the whole command, not just its prefix. A denied binary named anywhere in a compound command — including inside a heredoc body — blocks the entire call.
+- The matcher scans the whole command, not just its prefix. A denied binary named anywhere in a compound command — including inside a heredoc body — blocks the entire call. Evidenced twice: issue #250 records a blocked command beginning `SB=/tmp/…` with `chmod` eight lines later inside a heredoc, and the commit implementing this change was itself refused for naming a denied binary in its message.
 
 **Decisions:**
 
-*Rejected — dropping `chmod` from the rules entirely.* It would have removed the friction just as effectively, since an unmatched command runs under `bypassPermissions` and prompts in every other mode. `ask` was kept instead because `chmod` is the one entry here that can widen a file's reach to other users, which is worth a deliberate decision rather than a silent pass, and the entry documents that judgement where a deletion would leave nothing behind.
+*Rejected — dropping `chmod` from the rules entirely.* It would have removed the friction just as effectively, since an unmatched command runs under `bypassPermissions` and prompts in every other mode. `ask` was kept because `chmod` is the one entry here that can widen a file's reach to other users, which is worth a deliberate decision rather than a silent pass.
 
-*Rejected — leaving `git push` on `ask` and relying on the operator to approve it.* That is what stalled the pipeline in the first place, at the most expensive possible point: after the suite, the reviewers, the fix commits and the PR body were all done. `ask` also cannot work unattended at all — see the caveat below.
+*Rejected — pairing the `git push` allow with a `deny` on `--force`.* [`2026-09-04-rm-off-the-ask-list.md`](2026-09-04-rm-off-the-ask-list.md) anticipated shipping both halves together. Only the `allow` shipped, deliberately: permission rules match on textual prefix, so `Bash(git push --force:*)` would catch `git push --force` and miss `git push -f`, `git push origin main --force`, and every compound form. That is the same objection which sank a narrowed `rm` rule in that CIR — a guard a flag reorder defeats is worse than none, because it reads as protection. Force-push is therefore **unguarded as of this change**, which is a real reduction in cover, not an oversight: the honest fix is a `PreToolUse` hook that parses the command rather than a prefix rule, and that is worth its own issue.
+
+**Supersedes:** this record replaces the `git push` disposition in [`2026-09-04-rm-off-the-ask-list.md`](2026-09-04-rm-off-the-ask-list.md), which says `Bash(git push:*)` stays on `ask`. It no longer does. Both CIRs carry the same date, so that line is only readable in light of this one.
 
 **Caveat — `ask` is not a universal improvement on `deny`.** In an interactive session an `ask` rule prompts, which is the whole point of this change. In a headless `claude -p` worker it *denies silently*, because there is no surface to prompt on — indistinguishable in effect from the `deny` it replaced. So this restores `chmod`'s approval path for interactive work only; an unattended lane worker still loses it, and still loses it quietly. The originating issue argued that "`ask` at least surfaces the decision", which holds interactively and not headlessly. If a lane worker ever needs `chmod`, the fix is an `allow` rule, not this one. The interactive-versus-headless split is documented in [`../agentic-workflow-NetPace.md`](../agentic-workflow-NetPace.md#permissions-and-unattended-runs).
 
-*Note on the issue's evidence.* The issue cites `scripts/plugin-report.sh` being committed `100644` as damage caused by the deny rule. That has since been corrected — the file is `100755`, matching every sibling in `scripts/` and `.claude/hooks/` — so no file-mode repair was needed here.
+*Note on the issue's evidence.* The issue cites `scripts/plugin-report.sh` being committed `100644` as damage caused by the deny rule. That has since been corrected — the file is `100755`, matching every other shell script in `scripts/` and `.claude/hooks/` (`git-red-phase-commit.ps1` and `hooks/README.md` are non-executable by design) — so no file-mode repair was needed here.
 
 **Date:** 2026-09-04

--- a/docs/change-intent-records/2026-09-04-push-allow-chmod-ask.md
+++ b/docs/change-intent-records/2026-09-04-push-allow-chmod-ask.md
@@ -1,0 +1,24 @@
+# Allowing `git push`, and moving `chmod` from `deny` to `ask`
+
+**Intent:** Stop `/raise-pr` stalling at its push step, and stop `chmod` being a hard block with no approval path.
+
+**Behaviour:**
+- Given a `/ship` run in the project's own `defaultMode`, when it reaches `/raise-pr` step 7, then the push proceeds without a prompt.
+- Given an agent that needs to set an executable bit, when it runs `chmod`, then the decision is surfaced rather than refused outright.
+- Given a command naming privilege escalation (`sudo`, `su`, `chown`) or a network binary (`curl`, `wget`, `ssh`, `scp`), when it runs in any mode, then it is still refused.
+
+**Constraints:**
+- `deny` is enforced even in `bypassPermissions`, so a deny rule is a silent hard block mid-agent — no prompt, no approval path. That is right for exfiltration and privilege escalation, and wrong for a local file-mode change that grants no capability a shell does not already have.
+- The matcher scans the whole command, not just its prefix. A denied binary named anywhere in a compound command — including inside a heredoc body — blocks the entire call.
+
+**Decisions:**
+
+*Rejected — dropping `chmod` from the rules entirely.* It would have removed the friction just as effectively, since an unmatched command runs under `bypassPermissions` and prompts in every other mode. `ask` was kept instead because `chmod` is the one entry here that can widen a file's reach to other users, which is worth a deliberate decision rather than a silent pass, and the entry documents that judgement where a deletion would leave nothing behind.
+
+*Rejected — leaving `git push` on `ask` and relying on the operator to approve it.* That is what stalled the pipeline in the first place, at the most expensive possible point: after the suite, the reviewers, the fix commits and the PR body were all done. `ask` also cannot work unattended at all — see the caveat below.
+
+**Caveat — `ask` is not a universal improvement on `deny`.** In an interactive session an `ask` rule prompts, which is the whole point of this change. In a headless `claude -p` worker it *denies silently*, because there is no surface to prompt on — indistinguishable in effect from the `deny` it replaced. So this restores `chmod`'s approval path for interactive work only; an unattended lane worker still loses it, and still loses it quietly. The originating issue argued that "`ask` at least surfaces the decision", which holds interactively and not headlessly. If a lane worker ever needs `chmod`, the fix is an `allow` rule, not this one. The interactive-versus-headless split is documented in [`../agentic-workflow-NetPace.md`](../agentic-workflow-NetPace.md#permissions-and-unattended-runs).
+
+*Note on the issue's evidence.* The issue cites `scripts/plugin-report.sh` being committed `100644` as damage caused by the deny rule. That has since been corrected — the file is `100755`, matching every sibling in `scripts/` and `.claude/hooks/` — so no file-mode repair was needed here.
+
+**Date:** 2026-09-04

--- a/docs/change-intent-records/2026-09-04-read-deny-rules-removed.md
+++ b/docs/change-intent-records/2026-09-04-read-deny-rules-removed.md
@@ -1,0 +1,26 @@
+# Removing the `Read(…)` rules from `permissions.deny`
+
+**Intent:** Stop a recursive read of the repository escalating to a manual approval that no permission mode grants, which interrupted `/ship` step 2 when a reviewer subagent ran `grep -rn … .`.
+
+**Behaviour:**
+- Given a reviewer subagent in an interactive session, when it greps the repository root recursively, then it completes without an approval prompt.
+- Given any session, when Claude reads a file, then no `Read(…)` rule refuses it — that cover is gone, deliberately. See *What this gives up*.
+
+**Constraints:**
+- The escalation is **glob-scope-based, not existence-based**. The repository contains no `.env`, `secrets.*`, `.ssh/` or `appsettings*.json` file, yet the prompt fired naming `Read(**/.env)`, because the grep's read scope *could* contain a path the glob matches.
+- There was therefore no partial fix. Every rule was `**/`-anchored and so matchable somewhere under the working directory; trimming the list would have left the escalation intact.
+- It is an approval **no mode auto-grants** — `bypassPermissions` does not clear it, and neither does an `allow` rule. `Bash(grep:*)` was already allowed and the command escalated regardless.
+- It is **interactive-only**. Under `claude -p` the same greps run clean, verified across three shapes including the exact compound form that prompted.
+- Approval is memoised per session, so the cost was roughly one prompt per interactive session rather than one per grep.
+
+**Decisions:**
+
+*Rejected — converting the six rules from `deny` to `ask`.* Tested and reverted. It would have kept a surface on direct secret reads, but there was no evidence it stops the scope escalation, while it certainly weakens direct reads from never-readable to readable-after-one-approval. Weakening something real to buy something unverified is the worst of the options.
+
+*Rejected — keeping a subset.* Ruled out by the glob-scope constraint above.
+
+**What this gives up.** Claude can now read a `.env`, `secrets.*` or `appsettings*.json` file if one ever appears in this repository. The exposure is prospective, not live: a scan of the working tree at the time of this change found no file of any of those names, no key or certificate files, and no content matches for AWS keys, GitHub or Slack tokens, `sk-` keys, private-key headers, or quoted password/secret/token assignments. NetPace is a public CLI that holds no credentials by design, and the machine is a disposable sandbox. If the project ever does acquire a secret file, this decision needs revisiting — a `PreToolUse` hook that blocks reads of specific paths would restore the cover without reintroducing the scope escalation, because the escalation keys on `Read(…)` rules in settings rather than on hooks.
+
+**Verification gap — read this before trusting the change.** It could not be verified in the session that made it. Establishing a RED requires an un-memoised session, and the approval had already been granted here, so a clean before/after was no longer available; the headless oracle is blind to this class by the constraint above. The reasoning is sound and the mechanism is understood, but the fix is **unconfirmed by observation**. Confirm it in a fresh interactive session: run `grep -rn "<any term>" .` from the repository root as the first such command of the session and check that no approval prompt appears.
+
+**Date:** 2026-09-04


### PR DESCRIPTION
## Why

Three permission rules that between them stopped `/ship` running unattended. Two were named in #250; the third surfaced during the `/ship` run that shipped this branch and was scoped into the issue once it was understood.

`git push` sat on `permissions.ask`, so `/raise-pr` stalled at its push step — the second-to-last action of an otherwise complete pipeline, after the suite, the reviewers, the fix commits and the PR body were all done.

`chmod` was the odd entry in `deny`: the rest of that list is privilege escalation and network exfiltration, but `chmod` changes a local file mode and grants no capability a shell does not already have. `deny` is enforced even in `bypassPermissions`, so it was a silent hard block with no approval path, and it cost a reviewer the fixture it needed on #247.

The six `Read(…)` deny rules made any recursive read of the repository escalate to an approval no permission mode grants. A reviewer running `grep -rn … .` hit it during this branch's own review.

## What changes

- `Bash(git push:*)` → `allow`.
- `Bash(chmod:*)` → `ask` (from `deny`).
- The six `Read(…)` rules removed from `deny` — `.env`, `.env.*`, `secrets.*`, `.ssh/**`, `appsettings.*.json`, `appsettings.json`.
- `permissions.deny` keeps all seven of its Bash entries unchanged.
- Three CIRs, and the moves narrated in the workflow doc's permissions section.

## Non-obvious things a reviewer should know

**The `Read` rules are removed on a live-exposure argument, and that argument has a shelf life.** The escalation is glob-scope-based, not existence-based — the repo contains none of those files, yet the prompt fired naming `Read(**/.env)` — so there was no partial fix; every rule was `**/`-anchored and matchable somewhere under the working directory. Removing them means Claude can read such a file *if one ever appears*. A scan of the tree found none, plus no key or certificate files and no content matches for cloud keys, forge tokens, private-key headers or quoted credential assignments. If NetPace ever acquires a secret file, this needs revisiting — a `PreToolUse` hook would restore the cover without reintroducing the escalation, since the escalation keys on settings rules rather than hooks.

**That change is unconfirmed by observation, and the CIR says so.** Establishing a RED needs an un-memoised session; approval had already been granted in the session that made the change, and the headless oracle is blind to this class. The reasoning is sound, the mechanism understood, but it wants a fresh-session check — steps in the CIR.

**This branch also corrects a claim it introduced earlier.** "Headless is a permission oracle" is sound for `allow`/`ask`/`deny` matching but blind to escalations that need an interactive surface: these greps prompt interactively and run clean under `claude -p`. It answers "which rule matched", not "would a human have been asked".

**Force-push is now unguarded, deliberately.** The preceding CIR anticipated pairing the `git push` allow with a `deny` on `--force`. Only the `allow` shipped: rules match on textual prefix, so `Bash(git push --force:*)` catches `--force` and misses `-f`, `git push origin main --force`, and every compound form — the same objection that sank a narrowed `rm` rule a day earlier. A guard a flag reorder defeats is worse than none. A real reduction in cover, not an oversight; the honest fix is a parsing hook and wants its own issue.

**`ask` does not deliver what #250 expects, in the case that motivated it.** The issue argues `ask` beats `deny` because it "at least surfaces the decision". True interactively, false headlessly: a `claude -p` worker has no surface to prompt on, so an `ask` rule denies silently — indistinguishable from the `deny` it replaced. Implemented as written; gap documented.

**The issue's file-mode evidence is stale.** It cites `scripts/plugin-report.sh` at `100644` as damage from the deny rule. It is `100755`, corrected in #253, so no repair was needed.

## How to verify

- [ ] `dotnet build ./src && dotnet test ./src` — 648 passed, 0 skipped, 0 warnings.
- [ ] `permissions.ask` is exactly `["Bash(chmod:*)"]`; `Bash(git push:*)` is in `allow`; `deny` has no `Read(…)` entries and still lists the seven binaries.
- [ ] Headless oracle — a headless worker denies what a rule would stop, and the text distinguishes the kinds:
      `git push --dry-run …` → RAN (was: `requires user confirmation`)
      `chmod +x <file>` → `you haven't granted it yet` (was: `matches deny pattern Bash(chmod:*)`) — proving `ask`, not `deny`
      a denied network binary → `Blocked by security policy` (unchanged)
- [ ] **In a fresh interactive session**, as the first such command of that session: `grep -rn "<any term>" .` from the repo root completes with no approval prompt. This is the one check that could not be run here.

## Related

Closes #250.

Follow-ups deliberately not folded in: a parsing hook for force-push, and the `green-gate.sh` `statusMessage` noise the issue itself excludes.
