### PR TITLE
PR Closing Keyword

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -97,5 +97,5 @@ Two named exceptions, because `CLAUDE.md` requires discussion for them:
 - **What you changed**, at a behaviour level, and how each acceptance criterion is met.
 - **Any assumption** you made on an ambiguous point, any public-API change, and anything you deliberately left out of scope.
 - Then exactly one of:
-  - `READY branch=<branch>` — every criterion implemented, whole suite green, everything committed, tree clean. Follow with: "Run `/ship` to format, gate, review and raise the PR — `/raise-pr` derives `Closes #<N>` from this branch name and verifies it, so the issue closes on merge."
+  - `READY branch=<branch>` — every criterion implemented, whole suite green, everything committed, tree clean. Follow with: "Run `/ship` to format, gate, review and raise the PR — `/raise-pr` derives `Closes #<N>` from this branch name and verifies it before use, then reports what it settled; check that line to confirm the link was made."
   - `FAILED reason=<short reason>` — you could not reach that state. Report the wall you actually hit, discovered by working: the criteria conflict, they do not determine the design, the change is larger than they describe. Do not fabricate READY.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -97,5 +97,5 @@ Two named exceptions, because `CLAUDE.md` requires discussion for them:
 - **What you changed**, at a behaviour level, and how each acceptance criterion is met.
 - **Any assumption** you made on an ambiguous point, any public-API change, and anything you deliberately left out of scope.
 - Then exactly one of:
-  - `READY branch=<branch>` — every criterion implemented, whole suite green, everything committed, tree clean. Follow with: "Run `/ship` to format, gate, review and raise the PR — and add `Closes #<N>` to the PR body if you want the issue to close on merge."
+  - `READY branch=<branch>` — every criterion implemented, whole suite green, everything committed, tree clean. Follow with: "Run `/ship` to format, gate, review and raise the PR — `/raise-pr` derives `Closes #<N>` from this branch name and verifies it, so the issue closes on merge."
   - `FAILED reason=<short reason>` — you could not reach that state. Report the wall you actually hit, discovered by working: the criteria conflict, they do not determine the design, the change is larger than they describe. Do not fabricate READY.

--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -4,6 +4,14 @@ description: Raise a PR for the current feature branch — cleans up the spec fo
 
 Read `CLAUDE.md` for project context before proceeding.
 
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full issue URL — naming the issue this PR closes. Empty is the normal case and is **not** a prompt: step 6 infers the issue from the branch instead. `/raise-pr` never asks the invoker for anything, so it stays composable by `/ship` with no interactive gate.
+
 ## Steps
 
 1. **Get branch name**: Run `git rev-parse --abbrev-ref HEAD`. If the result is `main`, stop immediately and output: "Run /raise-pr from a feature branch, not main."
@@ -26,6 +34,16 @@ Read `CLAUDE.md` for project context before proceeding.
 
 6. **Compose PR body**: Write a description sized to the change. **Do not follow a fixed template.** Decide which sections earn their place based on what's actually in this PR.
 
+   **First, settle the closing keyword.** A merged PR must close the issue it implemented without the invoker having to remember to ask for it, so decide this every time — not only when someone thinks to mention an issue:
+
+   - **An issue number supplied by the invoker wins.** Take it from the User Input above (bare, `#N`, or an issue URL) and use it directly — no branch inference, no second-guessing.
+   - **Otherwise infer a candidate from the branch name.** `feature/<N>-<slug>` is what `/build` produces, so the leading number on the segment after the prefix is the candidate.
+   - **Verify the candidate before using it — never trust the parse.** Run `gh issue view <N> --json number,state,title,url`. Use `Closes #<N>` only if all three hold: the lookup succeeded, `state` is `OPEN`, and `url` is an `/issues/<N>` path. Otherwise add **no** closing keyword and carry on composing the body.
+   - Verifying is the point of the rule, not ceremony around it: spec-kit branches carry a *sequence* number, not an issue number — `004-raise-pr-command` is the very branch step 5 strips `004-` from — so an unverified parse would emit `Closes #4` and silently auto-close an unrelated issue the moment the PR merged. That is a worse failure than the missing link this rule exists to fix, and nobody notices it until an issue is mysteriously closed.
+   - The `url` check is not belt-and-braces. GitHub numbers issues and pull requests from one sequence, and `gh issue view <N>` resolves a *pull request* at that number rather than failing: on this repo `gh issue view 4` returns `{"number":4,"state":"MERGED","url":".../pull/4"}`. A state-only check therefore passes for an open PR and would emit a `Closes` aimed at a pull request. The `/issues/` path is what separates the two.
+   - The keyword goes on its own line in **Related**. The PR body is the *only* place a closing keyword belongs — never a commit message, which would close the issue as soon as it reached `main`, ahead of review.
+   - Whichever way it lands, step 10 reports it.
+
    **Guiding principle — don't duplicate things a reviewer can get elsewhere.** GitHub already shows:
    - the list of changed files and their diffs
    - the commit list and commit messages
@@ -40,7 +58,7 @@ Read `CLAUDE.md` for project context before proceeding.
    - **What changes** — a short summary of observable changes. For single-theme PRs, 1–3 bullets. For multi-theme PRs, group by theme rather than by file. Describe *what* changed at a behaviour level, not which files were touched.
    - **Non-obvious things a reviewer should know** — caveats, deliberate trade-offs, hidden invariants, anything in the diff that looks weird but is intentional. Omit if there are none.
    - **How to verify** — a markdown checklist of concrete actions a reviewer can perform. Derive items from what actually changed. Omit for pure-documentation PRs where there's nothing functional to exercise.
-   - **Related** — links to issues, prior PRs, or specs that give context. Omit if none.
+   - **Related** — the `Closes #<N>` line settled above, when one was settled, plus links to prior PRs, related issues, or specs that give context. Omit only if there is neither.
 
    A tiny PR may collapse to two sections. A sprawling PR may use all five. Match the size of the body to the size of the change.
 
@@ -60,4 +78,4 @@ Read `CLAUDE.md` for project context before proceeding.
    End the review with a recommendation whether to merge the PR, and if not, what you suggest needs addressing first.
    ```
 
-10. **Output result**: Print the PR URL. If step 4 deleted a spec folder, also print `Deleted spec folder: <FEATURE_DIR>`.
+10. **Output result**: Print the PR URL. If step 4 deleted a spec folder, also print `Deleted spec folder: <FEATURE_DIR>`. Always print what step 6 settled — `Closes #<N> — <issue title>`, or, when it settled nothing, that fact and the reason (`No closing keyword: branch carries no issue number`; `No closing keyword: #4 is a pull request, not an open issue`) — so the invoker can see from the output alone whether merging this PR will close anything, and what.

--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -10,7 +10,7 @@ Read `CLAUDE.md` for project context before proceeding.
 $ARGUMENTS
 ```
 
-Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full issue URL — naming the issue this PR closes. Empty is the normal case and is **not** a prompt: step 6 infers the issue from the branch instead. `/raise-pr` never asks the invoker for anything, so it stays composable by `/ship` with no interactive gate.
+Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full issue URL — naming the issue this PR closes. Empty is the normal case and is **not** a prompt: step 6 infers a candidate from the branch instead. `/raise-pr` never asks the invoker for anything, so it stays composable by `/ship` with no interactive gate.
 
 ## Steps
 
@@ -36,12 +36,17 @@ Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full is
 
    **First, settle the closing keyword.** A merged PR must close the issue it implemented without the invoker having to remember to ask for it, so decide this every time — not only when someone thinks to mention an issue:
 
-   - **An issue number supplied by the invoker wins.** Take it from the User Input above (bare, `#N`, or an issue URL) and use it directly — no branch inference, no second-guessing.
-   - **Otherwise infer a candidate from the branch name.** `feature/<N>-<slug>` is what `/build` produces, so the leading number on the segment after the prefix is the candidate.
-   - **Verify the candidate before using it — never trust the parse.** Run `gh issue view <N> --json number,state,title,url`. Use `Closes #<N>` only if all three hold: the lookup succeeded, `state` is `OPEN`, and `url` is an `/issues/<N>` path. Otherwise add **no** closing keyword and carry on composing the body.
-   - Verifying is the point of the rule, not ceremony around it: spec-kit branches carry a *sequence* number, not an issue number — `004-raise-pr-command` is the very branch step 5 strips `004-` from — so an unverified parse would emit `Closes #4` and silently auto-close an unrelated issue the moment the PR merged. That is a worse failure than the missing link this rule exists to fix, and nobody notices it until an issue is mysteriously closed.
-   - The `url` check is not belt-and-braces. GitHub numbers issues and pull requests from one sequence, and `gh issue view <N>` resolves a *pull request* at that number rather than failing: on this repo `gh issue view 4` returns `{"number":4,"state":"MERGED","url":".../pull/4"}`. A state-only check therefore passes for an open PR and would emit a `Closes` aimed at a pull request. The `/issues/` path is what separates the two.
-   - The keyword goes on its own line in **Related**. The PR body is the *only* place a closing keyword belongs — never a commit message, which would close the issue as soon as it reached `main`, ahead of review.
+   - **Find a candidate.** A number supplied by the invoker wins over anything inferred. Otherwise take the leading number off a branch matching the `<prefix>/<N>-<slug>` shape `/build` produces, so `feature/248-pr-closing-keyword` yields `248`. Two shapes yield **no candidate**: a branch with no leading number on that segment (`feature/build-command`), and a bare `NNN-<slug>` spec-kit branch (`004-raise-pr-command`) — spec-kit numbers are *sequence* numbers that restart from `001`, so parsing one and trusting the check below to reject it is strictly worse than never parsing it. Never hunt for a number elsewhere in the name: `feature/net10-upgrade` must not yield `10`. Normalise whatever you found to a bare number — `248`, `#248` and an issue URL all reduce to `248` (strip `#` and any leading zeros, take the trailing number from a URL) — and use that as `<N>` in every check and message below.
+   - **A candidate is only ever a candidate.** However it arrived — typed by the invoker or parsed from the branch — it is unverified until `gh` confirms it. The invoker's number wins the *sourcing*, never the *checking*: a hand-typed digit is if anything easier to get wrong than a parse, so `/raise-pr 247` (a PR number) and `/raise-pr 24` (a slip for `248`) must not sail through.
+   - **Verify it.** Resolve this repo once with `gh repo view --json nameWithOwner -q .nameWithOwner`, then run `gh issue view <N> --json number,state,title,url -R <owner>/<repo>`. Use `Closes #<N>` only if the command exits 0, `state` is `OPEN`, and `url` is exactly `https://github.com/<owner>/<repo>/issues/<N>`.
+   - That one URL equality is doing three jobs, each of which otherwise produces a confident `Closes` aimed at the wrong thing. GitHub numbers issues and pull requests from a single sequence, so `gh issue view` resolves a *pull request* at that number instead of failing — here `gh issue view 4` returns `{"state":"MERGED","url":".../pull/4"}`. `gh issue view <issue URL>` resolves against *that URL's* repo, so a pasted `github.com/cli/cli/issues/14353` verifies clean and would emit a `Closes #14353` that means something unrelated in this repo. And a transferred issue redirects to a different number. Comparing the whole URL rejects all three at once.
+   - **Report one of three outcomes — never fold the last two together.**
+     - **Linked** — every condition held. Put `Closes #<N>` on its own line in **Related**.
+     - **No issue** — the lookup settled the question. Either it exited 0 and the answer disqualifies the number (a pull request, an issue already `CLOSED`, or an issue in another repo), or it exited non-zero saying `Could not resolve to an issue or pull request`, which is GitHub definitively answering that nothing exists at `<N>`. Add no closing keyword. When it is a real but closed issue in *this* repo, still record `Refs #<N>` in **Related**: dropping the closing keyword is the safety property, dropping every trace of the link is collateral damage.
+     - **Unverified** — the lookup could not answer at all: expired auth, no network, rate limit, `gh` missing. Add no closing keyword, and say the check could not run, quoting `gh`'s stderr. Read the stderr, not the exit code, to tell this from the case above — both exit non-zero, but `HTTP 401: Bad credentials` is a broken check while `Could not resolve to an issue or pull request` is an answer. Reporting a fixable auth failure as "no such issue" sends the invoker looking in the wrong place.
+   - A non-zero `gh issue view` here is **not** a `/ship` step failure despite that command's global stop-on-failure rule — it is an abstain, reported rather than fatal. Compose the rest of the body and carry on.
+   - What this proves is bounded, and worth knowing: that `<N>` is an open issue in this repo, never that it is *this branch's* issue, and it can change state between here and merge. Restricting inference to the `/build` shape is what keeps that gap narrow.
+   - The PR body is the *only* place a closing keyword belongs — never a commit message, which would close the issue as soon as it reached `main`, ahead of review.
    - Whichever way it lands, step 10 reports it.
 
    **Guiding principle — don't duplicate things a reviewer can get elsewhere.** GitHub already shows:
@@ -58,7 +63,7 @@ Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full is
    - **What changes** — a short summary of observable changes. For single-theme PRs, 1–3 bullets. For multi-theme PRs, group by theme rather than by file. Describe *what* changed at a behaviour level, not which files were touched.
    - **Non-obvious things a reviewer should know** — caveats, deliberate trade-offs, hidden invariants, anything in the diff that looks weird but is intentional. Omit if there are none.
    - **How to verify** — a markdown checklist of concrete actions a reviewer can perform. Derive items from what actually changed. Omit for pure-documentation PRs where there's nothing functional to exercise.
-   - **Related** — the `Closes #<N>` line settled above, when one was settled, plus links to prior PRs, related issues, or specs that give context. Omit only if there is neither.
+   - **Related** — the `Closes #<N>` (or `Refs #<N>`) line settled above, plus links to prior PRs, related issues, or specs that give context. This section always survives when step 6 settled a keyword, whatever the PR's size.
 
    A tiny PR may collapse to two sections. A sprawling PR may use all five. Match the size of the body to the size of the change.
 
@@ -78,4 +83,4 @@ Optionally a GitHub issue number — bare (`248`), hashed (`#248`), or a full is
    End the review with a recommendation whether to merge the PR, and if not, what you suggest needs addressing first.
    ```
 
-10. **Output result**: Print the PR URL. If step 4 deleted a spec folder, also print `Deleted spec folder: <FEATURE_DIR>`. Always print what step 6 settled — `Closes #<N> — <issue title>`, or, when it settled nothing, that fact and the reason (`No closing keyword: branch carries no issue number`; `No closing keyword: #4 is a pull request, not an open issue`) — so the invoker can see from the output alone whether merging this PR will close anything, and what.
+10. **Output result**: Print the PR URL. If step 4 deleted a spec folder, also print `Deleted spec folder: <FEATURE_DIR>`. Then print step 6's outcome in whichever of its three forms applies — `Closes #<N> — <issue title>`; `No closing keyword: <reason>` (the branch carries no issue number; `#<N>` is a pull request; `#<N>` is closed); or `Closing keyword unverified: <gh stderr>` — so the invoker can see from the output alone what merging this PR will close, if anything.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -4,6 +4,14 @@ description: Orchestrator that turns "implementation looks done" into a reviewed
 
 Read `CLAUDE.md` for project context before proceeding.
 
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Optionally a GitHub issue number naming the issue this ship should close. Empty is the normal case and is **not** a prompt — step 4 forwards whatever is here to `/raise-pr`, which otherwise infers a candidate from the branch name.
+
 `/ship` composes NetPace's existing commands behind one hard gate: **the full test suite gates everything downstream, and no review or PR happens unless it is green.** The gate is structural — the review step is downstream of the step-1 exit code, so it cannot begin against un-verified or red code. Do not add a hook to police this ordering; the exit code *is* the gate. The one step that precedes the suite is formatting (step 1a), which is cosmetic and is itself covered by the gate that follows it.
 
 `/ship` is designed to run to completion **without prompting**, so it can be driven by an automated loop (e.g. shipping many features back-to-back) as well as invoked directly. Reflection (`/capture-learnings`) is deliberately **not** a step: it needs human curation and batches better across many features, so it belongs at a supervised checkpoint after a batch — not inside each ship, where it would either block the loop or be auto-skipped to nothing. `/ship` likewise never waits on the async `@claude` PR review (see below).
@@ -55,7 +63,7 @@ Read `CLAUDE.md` for project context before proceeding.
      - Re-run `dotnet build ./src && dotnet test ./src`. Not green ⇒ STOP and report.
      - Once green, **commit the edits** with `git add -A` and a clear message (e.g. `fix: apply /ship review findings`). This is what makes the fixes reach the pushed PR — `/raise-pr` pushes *commits*, so uncommitted or untracked working-tree edits would silently never ship. `git add -A` is correct and complete here precisely because the tree started clean: it stages every review edit (including new untracked files and deletions) with no risk of sweeping in unrelated local changes.
 
-4. **Raise the PR (final step).** Compose and open the PR via `/raise-pr`. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here and report.
+4. **Raise the PR (final step).** Compose and open the PR via `/raise-pr`, forwarding any issue number from the User Input above — that pass-through is the only route by which an explicit override reaches the PR body on this path, since `/raise-pr` is never invoked directly here. With nothing supplied it infers a candidate from the branch name and verifies it, which covers the normal `/build` case. It pushes the branch (now carrying the step-3 fix commit, if any) and requests the async `@claude` GitHub-action review. If `/raise-pr` aborts (push rejected, `gh pr create` fails because the PR already exists), STOP here and report.
 
    `/ship` ends at the raised PR. It does **not** run `/capture-learnings`, and does **not** wait on or prompt about the async `@claude` review (Review B, see below). Its closing output carries one soft nudge — "PR raised; the `@claude` review posts async — run `/capture-learnings` when you next review the batch" — a free reminder, never a gate or a wait.
 
@@ -66,4 +74,4 @@ Read `CLAUDE.md` for project context before proceeding.
 
 ## Final report
 
-Report to the invoker: whether formatting changed anything (and the commit if it did), the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, and the soft `/capture-learnings` nudge.
+Report to the invoker: whether formatting changed anything (and the commit if it did), the suite result(s), which review findings were fixed-and-committed and which were deferred as out-of-scope follow-ups (if any), the PR URL, what `/raise-pr` settled for the closing keyword (linked, no issue, or unverified — an unverified lookup is fixable in seconds and worth surfacing, not swallowing), and the soft `/capture-learnings` nudge.


### PR DESCRIPTION
## Why

A merged PR did not close the issue it implemented unless the invoker remembered to type `Closes #<N>` by hand. `/raise-pr` step 6 only suggested "links to issues… that give context", which mandates nothing. #248 has the evidence: of the eight merged PRs before it, one carried a closing keyword.

The obvious mechanism — take the number off the branch name — is unsafe, and #248 says why: spec-kit branches carry a *sequence* number, not an issue number, so `004-raise-pr-command` would emit `Closes #4` and silently auto-close something unrelated. The number has to be **verified**, not merely parsed.

## What changes

- `/raise-pr` settles a closing keyword on every run: an invoker-supplied number wins the *sourcing*, the branch supplies a candidate otherwise, and either way `gh` verifies it before use.
- The outcome is three-way — linked, no issue, or unverifiable — and is reported, so the invoker can see what merging will close without opening GitHub.
- `/ship` forwards an issue number through to `/raise-pr` and surfaces the outcome in its final report.
- `/build`'s READY message no longer tells the invoker to add the keyword by hand.

This PR is its own first exercise of the feature: the `Closes #248` below was derived from the branch name and verified, not typed.

## Non-obvious things a reviewer should know

**Verification proves existence and openness, never identity.** It confirms `<N>` is an open issue in this repo — never that it is *this branch's* issue. That gap is held narrow by restricting inference to the `/build` branch shape rather than by the check itself, and the prose says so rather than implying the check is stronger than it is.

**A single URL-equality test replaces three separate checks.** Requiring `url` to equal this repo's `/issues/<N>` rejects, in one comparison, a pull request at that number, an issue in another repo, and a transferred issue that redirected. Each was reproduced against the live tool first:

- `gh issue view 4` returns `{"state":"MERGED","url":".../pull/4"}` — it resolves a *PR* rather than failing, so a state-only check would have passed for an open PR. This one was found by exercising the rule, not by reading it.
- `gh issue view https://github.com/cli/cli/issues/14353` run from inside NetPace returns OPEN at an `/issues/` path — a pasted cross-repo link verified clean and would have emitted a `Closes` meaning something else here.

**"No such issue" and "couldn't check" both exit 1.** A nonexistent issue and an expired token are indistinguishable by exit code, so the rule reads stderr instead: `Could not resolve to an issue or pull request` is an answer, `HTTP 401: Bad credentials` is a broken check. Folding them together would report a fixable auth failure as "branch carries no issue number" and send the invoker looking in the wrong place.

**Branch inference deliberately declines more than it accepts.** A bare `NNN-` spec-kit branch yields *no* candidate rather than one the checker is trusted to reject, and the number is only ever read from the start of the segment — `feature/net10-upgrade` must not yield `10`. False negatives here are the safe direction; the cost is a missing link, not a wrongly-closed issue.

**A failed lookup is an abstain, not a `/ship` failure.** `/ship`'s stop-on-failure rule is global, so the exception is named explicitly to stop the two documents disagreeing.

## Corrected reasoning, recorded so it is not cited again

The `/build` report justified adding no CI gate on the grounds that the only gate shape would false-positive on issue-less PRs. That was wrong — it defeats only the *unconditional* gate. A gate conditioned on branch shape has no such problem: across the last 25 merged PRs, all 6 `feature/<N>-` branches carry a keyword and every other branch is exempt by construction, dependabot included. Zero false positives. Opened as **#263** rather than built here, because its `No-close:` escape hatch is new repo policy and a second mission.

Also worth stating plainly: the grep showing the old prompt mandated nothing is a diff summary, not RED evidence — the string matches because it was typed in. The real RED→GREEN is the `gh` probe sequence above, where a candidate rule was executed, produced a wrong answer against a real input, and was strengthened until all cases separated.

## How to verify

- [ ] `gh issue view 4 --json state,url` — confirm it resolves a *pull request*, which is what makes the URL check load-bearing rather than belt-and-braces.
- [ ] `gh issue view https://github.com/cli/cli/issues/14353 --json state,url` from this repo — confirm a cross-repo URL still returns OPEN at an `/issues/` path.
- [ ] `GH_TOKEN=invalid gh issue view 248` vs `gh issue view 999999` — confirm both exit 1 with different stderr, so only stderr can separate them.
- [ ] Read `raise-pr.md` step 6 as an agent would: does any path reach `Closes` without passing all three conditions?

## Related

Closes #248

- #263 — follow-up: gate this invariant in CI, conditioned on branch shape.
- PR #247 — where the missing linkage was noticed; `Closes #235` was supplied by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxP7idFUPigWdvUMPtuFuX