### PR TITLE
Ready Label On Confirm

### DIFF
--- a/.claude/commands/speckit.confirmissue.md
+++ b/.claude/commands/speckit.confirmissue.md
@@ -27,6 +27,7 @@ Sits **between** `/speckit.reviewissue` and `/speckit.specify`.
 1. Reads the answered review comment.
 2. Pairs each gap's `**Recommendation:**` with the author's `> _Answer:_` to produce a **one-line decision** per gap.
 3. Appends (or rewrites, if already present) a `## Confirmed decisions` section at the end of the issue body.
+4. Applies the `ready` label, marking the issue fully defined without anyone having to open it.
 
 The original review comment is left untouched — it serves as the natural audit trail of how each decision was reached.
 
@@ -158,7 +159,21 @@ gh api --method PATCH repos/<owner>/<repo>/issues/<number> --input .claude/scrat
 (Omit the leading `/` on the endpoint — Git Bash on Windows rewrites `/repos/...`
 as a filesystem path. `gh api` accepts both forms on Linux/macOS.)
 
-### 6. Do not touch the review comment
+### 6. Apply the `ready` label
+
+With the body patched, mark the issue as fully defined:
+
+```bash
+gh issue edit <number> --repo <owner/repo> --add-label ready
+```
+
+- **Additive only.** `--add-label` adds `ready` and touches nothing else — every label the issue already carries stays on it. Never pass `--remove-label` here; tidying `needs triage` or anything else alongside it is a manual call.
+- **Idempotent.** Adding a label an issue already carries is a no-op on GitHub's side, so re-running this command on an already-`ready` issue leaves it `ready` and reports no error.
+- **Never fatal.** If the label cannot be applied, do **not** fail the command — the decisions are already saved. Continue to the report and say there that the label did not land.
+
+Ordering matters both ways: the body patch runs first so a label failure can never leave the decisions unsaved, and this step sits downstream of step 2's hard-stops so an issue with an unanswered or hedging gap can never come out labelled `ready`.
+
+### 7. Do not touch the review comment
 
 The answered review comment is the audit trail. Leave it intact. Do not delete, edit, or annotate it.
 
@@ -170,6 +185,7 @@ Keep your chat response short:
 
 - confirm the issue updated (number + title)
 - state how many decisions were folded in (and the count by pattern: e.g. "8 accepted, 1 with rider, 1 redirected")
+- state whether the `ready` label was applied — and if it was not, say so explicitly, noting the decisions were saved regardless
 - return the issue URL
 
 If you stopped at step 1 or 2, report which precondition failed and what to fix.

--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -42,7 +42,7 @@ A useful frame is the **five duties of a harness** (OpenAI): the harness must **
 ### Per-feature — Spec & planning (on the main branch)
 1.  `/speckit.draftissue`    ← optional; turn an unstructured brief into a well-formed issue
 2.  `/speckit.reviewissue`   ← pre-spec gate; posts gaps + recommendations as an issue comment
-3.  `/speckit.confirmissue`  ← fold answered review into a `## Confirmed decisions` section
+3.  `/speckit.confirmissue`  ← fold answered review into a `## Confirmed decisions` section, and label the issue `ready`
 4.  `/speckit.specify`
 5.  `/speckit.clarify`       ← iterate until the spec feels complete
 6.  `/speckit.checklist`     ← resolve all gaps before continuing


### PR DESCRIPTION
## Why

`/speckit.confirmissue` finished by patching the issue body and left no mark on the issue's own state, so "this issue is fully defined" was invisible from the issue list — you had to open each one. `ready` already exists and already means exactly that. Applying it here also completes the label state machine #271 starts at the other end: `review` = review pending → removed = reviewed → `ready` = defined.

## What changes

- `/speckit.confirmissue` now applies the `ready` label after it patches the issue body. Additive only — no other label is added, removed or altered, `needs triage` included.
- The command's report says whether the label landed. A label failure is never fatal: the decisions are already saved by then, and the report says so.
- The pipeline description in `docs/agentic-workflow.md` says the confirm step marks the issue ready.

## Non-obvious things a reviewer should know

- **The organic evidence run the issue asks for does not exist yet, and I could not produce one.** The issue calls for "one real run linked in the PR: an issue without `ready` that carries it after `/speckit.confirmissue`". No open issue is in a state where the command can complete: only #260 carries a `<!-- speckit:review -->` comment and all ten of its `> _Answer:_` slots are empty, so the command hard-stops at step 2. #274 itself has no review comment and already carries `ready`, applied by hand. Manufacturing a candidate would mean inventing answers on a real issue or opening a throwaway one — scaffolding of the kind this issue explicitly rejects for the failure path. **The next real confirm run on an unlabelled issue is the evidence**; this PR ships without it rather than staging it.
- **This is a configuration/tooling change, not production code**, so per Constitution I's carve-out the RED-GREEN evidence is the real state failing and passing, not an xUnit test. RED: `grep -rn -- "--add-label|--remove-label" .claude/` returned nothing — no command in the repo wrote any label; and #274 carries a `## Confirmed decisions` section yet its `ready` label came from `FrankRay78` in the issue timeline, not from the command. GREEN: the same grep now finds the label write, and line 45 of the workflow doc names it. Full suite run anyway and unaffected: 648 passed, 0 failed, 0 skipped, 0 warnings.
- **AC 5 (label failure keeps the decisions saved) is design intent, verified by reading the command text**, as the issue directed. Staging it would mean inventing a bogus label name purely to watch an error path.
- **No new gate guards AC 4.** An issue with an unanswered or hedging review can't come out `ready` because the label step sits downstream of step 2's existing hard-stops — the ordering is the guarantee, and it is written into the step so a future editor doesn't move it.
- Idempotency (AC 3) rests on GitHub treating `--add-label` of an existing label as a no-op, which preserves the command's stated "re-running is harmless".
- I also added the label to the command's `## Purpose` list, beyond the issue's stated file touchpoints, so that summary doesn't describe a command that now does more than it says.

## How to verify

- [ ] Read the new step 6 in `.claude/commands/speckit.confirmissue.md` — it runs after step 5's body patch, and before step 7's "do not touch the review comment".
- [ ] Confirm nothing in the diff can remove a label: `grep -rn -- "--remove-label" .claude/` finds only the prose forbidding it.
- [ ] Check the ordering claim holds against step 2's hard-stops — an unanswered or hedging answer returns before any body patch, so the label step is unreachable.
- [ ] Next time an issue's review comes back fully answered, run `/speckit.confirmissue #N` on it and confirm the label lands — that is the outstanding evidence noted above.

## Related

Closes #274

- #271 — makes `review` the trigger for the automated pre-specification review and removes it after posting. This PR completes the other end of the same label state machine.
- [docs/agentic-workflow.md:163](https://github.com/FrankRay78/NetPace/blob/main/docs/agentic-workflow.md#L163) — "prefer the tracker's own state as that ledger", the principle this change applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaRuiUQHdPMeGugFuvGfeK
